### PR TITLE
Fix/helpers cleanup

### DIFF
--- a/shared/helpers.ts
+++ b/shared/helpers.ts
@@ -1,211 +1,170 @@
-import { app } from 'electron';
-import { http, https } from 'follow-redirects';
-import path from 'path';
-import fs from 'fs-extra';
-import os from 'os';
-import { platform, arch } from 'process';
-import simpleGit from 'simple-git';
+import { app } from 'electron'
+import { http, https } from 'follow-redirects'
+import path from 'path'
+import fs from 'fs-extra'
+import os from 'os'
+import { platform, arch } from 'process'
 
+const getOSAndArch = () => {
+  console.log('platform', platform)
+  // Returned values: mac, linux-x86_64, linux-i686, win64, win32, or throws an error
+  let osAndArch = ''
 
-export class Helpers {
-
-
-    private flagPath = "installer-finished";
-
-    getOSAndArch() {
-        console.log('platform', platform)
-        /*
-            Returned values: mac, linux-x86_64, linux-i686, win64, win32, or throws an error
-         */
-        let osAndArch = '';
-
-        if (platform === 'darwin') {
-            osAndArch = 'mac';
-        }
-        if (platform === 'linux') {
-            if (arch === 'x64') {
-                osAndArch = 'linux-x86_64';
-            }
-            if (arch === 'x32') {
-                osAndArch = 'linux-i686';
-            }
-        }
-        if (platform === 'win32') {
-            if (arch === 'x64') {
-                osAndArch = 'win64';
-            }
-            if (arch === 'x32') {
-                osAndArch = 'win32';
-            }
-        }
-
-        return osAndArch;
+  if (platform === 'darwin') {
+    osAndArch = 'mac'
+  }
+  if (platform === 'linux') {
+    if (arch === 'x64') {
+      osAndArch = 'linux-x86_64'
     }
-
-    getPlatform() {
-        global.platform = {
-            darwin: platform === 'darwin',
-            linux: platform === 'linux',
-            win32: platform === 'win32'
-        }
+    if (arch === 'x32') {
+      osAndArch = 'linux-i686'
     }
-
-    getHTTPorHTTPs() {
-        if (global.platform.win32) {
-            return https;
-        }
-        return http;
+  }
+  if (platform === 'win32') {
+    if (arch === 'x64') {
+      osAndArch = 'win64'
     }
-
-    fixPath(pathStr: string) {
-        if (global.platform.win32) {
-            return pathStr.split(path.sep).join(path.posix.sep);
-        }
-        // linux & mac
-        return pathStr;
+    if (arch === 'x32') {
+      osAndArch = 'win32'
     }
+  }
 
-    async getPNPath(osAndArch: any) {
-        // const definitelyPosix = projectDir.split(path.sep).join(path.posix.sep);
-        return path.join(os.homedir(), '.point', 'src', 'pointnetwork');
-    }
-
-    async getDashboardPath(osAndArch: any) {
-        return path.join(os.homedir(), '.point', 'src', 'pointnetwork-dashboard');
-    }
-
-    async getSDKPath(osAndArch: any) {
-        return path.join(os.homedir(), '.point', 'src', 'pointsdk');
-    }
-
-    async getBrowserFolderPath(osAndArch: any) {
-        // const definitelyPosix = projectDir.split(path.sep).join(path.posix.sep);
-        const browserDir = path.join(os.homedir(), '.point', 'src', 'point-browser');
-        if (!fs.existsSync(browserDir)) {
-            fs.mkdirpSync(browserDir);
-        }
-        return browserDir;
-    }
-
-    getHomePath() {
-        // TODO: Delete if `os.homedir` works for Windows, too (because of WSL).
-        // If not, work with the commented code below.
-
-        // if (global.platform.win32) {
-        //     // NOTE: `wsl echo $HOME` doesn't work.
-        //     const cmd = `wsl realpath ~`;
-        //     try {
-        //         const result = await exec(cmd);
-        //         return result.stdout.trim();
-        //     } catch(ex) {
-        //         throw ex;
-        //     }
-        // }
-
-        return os.homedir();
-    }
-
-    async getLiveDirectoryPath() {
-        const homedir = await this.getHomePath();
-        return path.join(homedir, ".point", "keystore");
-    }
-
-    async getKeyFileName() {
-        return path.join(await this.getLiveDirectoryPath(), "key.json");
-    }
-
-    async getArweaveKeyFileName() {
-        return path.join(await this.getLiveDirectoryPath(), "arweave.json");
-    }
-
-    async isLoggedIn() {
-        return fs.existsSync(await this.getKeyFileName());
-    }
-
-    async logout() {
-        // Removing key files.
-        fs.unlinkSync(await this.getKeyFileName());
-        fs.unlinkSync(await this.getArweaveKeyFileName());
-        // Relaunching the dashboard to ask for key or generate a new one.
-        app.relaunch()
-        app.exit()
-    }
-
-    isDirEmpty(path: fs.PathLike) {
-        return fs.readdirSync(path).length === 0;
-    }
-
-    isDirsExist(paths: any[]) {
-        return paths.every((path: fs.PathLike) => {
-            if (!fs.existsSync(path)) {
-                return false;
-            }
-            return null;
-        });
-    }
-
-    async getPointPath(osAndArch: any) {
-        const pointPath = path.join(os.homedir(), '.point/');
-
-        if (!fs.existsSync(pointPath)) {
-            fs.mkdirSync(pointPath);
-        }
-
-        return pointPath;
-    }
-
-    async getPointSrcPath(osAndArch: any) {
-        const pointPath = module.exports.getPointPath(osAndArch);
-        const pointSrcPath = path.join(pointPath, 'src/');
-
-        if (!fs.existsSync(pointSrcPath)) {
-            fs.mkdirSync(pointSrcPath);
-        }
-
-        return pointSrcPath;
-    }
-
-    async getPointSoftwarePath(osAndArch: any) {
-        const pointPath = module.exports.getPointPath(osAndArch);
-        const pointSWPath = path.join(pointPath, 'software/');
-
-        if (!fs.existsSync(pointSWPath)) {
-            fs.mkdirSync(pointSWPath);
-        }
-
-        return pointSWPath;
-    }
-
-    async isPNCloned(osAndArch: any) {
-        const pnPath = await module.exports.getPNPath(osAndArch);
-        return fs.existsSync(pnPath);
-    }
-
-    async isDashboardCloned(osAndArch: any) {
-        const dashboardPath = await module.exports.getDashboardPath(osAndArch);
-        return fs.existsSync(dashboardPath);
-    }
-
-    async isSDKCloned(osAndArch: any) {
-        const sdkPath = await module.exports.getSDKPath(osAndArch);
-        return fs.existsSync(sdkPath);
-    }
-
-    async clonePN(pnPath: any, osAndArch: any) {
-        const git = simpleGit(module.exports.getPointSrcPath(osAndArch));
-        const pnURL = 'https://github.com/pointnetwork/pointnetwork';
-
-        await git.clone(pnURL, pnPath, (err: any) => { if (err) throw err; });
-        await git.cwd({ path: pnPath, root: true });
-    }
-
-    async isInstallationDone() {
-        const pointPath = await module.exports.getPointPath();
-        return fs.pathExistsSync(path.join(pointPath, this.flagPath));
-    }
-
-    async setInstallationDone() {
-        const pointPath = await module.exports.getPointPath();
-        fs.writeFileSync(path.join(pointPath, this.flagPath), "");
-    }
+  return osAndArch
 }
+
+const getPlatform = () => {
+  global.platform = {
+    darwin: platform === 'darwin',
+    linux: platform === 'linux',
+    win32: platform === 'win32',
+  }
+}
+
+const getHTTPorHTTPs = () => {
+  if (global.platform.win32) {
+    return https
+  }
+  return http
+}
+
+const fixPath = (pathStr: string) => {
+  if (global.platform.win32) {
+    return pathStr.split(path.sep).join(path.posix.sep)
+  }
+  // linux & mac
+  return pathStr
+}
+
+const getHomePath = () => {
+  return os.homedir()
+}
+
+const getPNPath = async () => {
+  return path.join(getHomePath(), '.point', 'src', 'pointnetwork')
+}
+
+const getDashboardPath = async () => {
+  return path.join(getHomePath(), '.point', 'src', 'pointnetwork-dashboard')
+}
+
+const getSDKPath = async () => {
+  return path.join(getHomePath(), '.point', 'src', 'pointsdk')
+}
+
+const getBrowserFolderPath = async () => {
+  const browserDir = path.join(getHomePath(), '.point', 'src', 'point-browser')
+  if (!fs.existsSync(browserDir)) {
+    fs.mkdirpSync(browserDir)
+  }
+  return browserDir
+}
+
+const getLiveDirectoryPath = async () => {
+  return path.join(await getHomePath(), '.point', 'keystore')
+}
+
+const getKeyFileName = async () => {
+  return path.join(await getLiveDirectoryPath(), 'key.json')
+}
+
+const getArweaveKeyFileName = async () => {
+  return path.join(await getLiveDirectoryPath(), 'arweave.json')
+}
+
+const isLoggedIn = async () => {
+  return fs.existsSync(await getKeyFileName())
+}
+
+const logout = async () => {
+  // Removing key files.
+  fs.unlinkSync(await getKeyFileName())
+  fs.unlinkSync(await getArweaveKeyFileName())
+  // Relaunching the dashboard to ask for key or generate a new one.
+  app.relaunch()
+  app.exit()
+}
+
+const getPointPath = () => {
+  const pointPath = path.join(getHomePath(), '.point/')
+
+  if (!fs.existsSync(pointPath)) {
+    fs.mkdirSync(pointPath)
+  }
+
+  return pointPath
+}
+
+const getPointSrcPath = async () => {
+  const pointSrcPath = path.join(getPointPath(), 'src/')
+
+  if (!fs.existsSync(pointSrcPath)) {
+    fs.mkdirSync(pointSrcPath)
+  }
+
+  return pointSrcPath
+}
+
+const getPointSoftwarePath = async () => {
+  const pointSWPath = path.join(getPointPath(), 'software/')
+
+  if (!fs.existsSync(pointSWPath)) {
+    fs.mkdirSync(pointSWPath)
+  }
+
+  return pointSWPath
+}
+
+const isPNCloned = async () => {
+  return fs.existsSync(await getPNPath())
+}
+
+const isDashboardCloned = async () => {
+  return fs.existsSync(await getDashboardPath())
+}
+
+const isSDKCloned = async () => {
+  return fs.existsSync(await getSDKPath())
+}
+
+export default Object.freeze({
+  getOSAndArch,
+  getPlatform,
+  getHTTPorHTTPs,
+  fixPath,
+  getPNPath,
+  getDashboardPath,
+  getSDKPath,
+  getBrowserFolderPath,
+  getHomePath,
+  getLiveDirectoryPath,
+  getKeyFileName,
+  getArweaveKeyFileName,
+  isLoggedIn,
+  logout,
+  getPointSrcPath,
+  getPointSoftwarePath,
+  isPNCloned,
+  isDashboardCloned,
+  isSDKCloned,
+})

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -3,14 +3,14 @@ import path from 'path'
 import _7z from '7zip-min'
 import tarfs from 'tar-fs'
 import url from 'url'
-import { Helpers } from '../../shared/helpers'
+import helpers from '../../shared/helpers'
 import util from 'util'
 import https from 'follow-redirects'
 import { BrowserWindow } from 'electron'
 
-const dmg = require("dmg")
+const dmg = require('dmg')
 const bz2 = require('unbzip2-stream')
-const find = require('find-process');
+const find = require('find-process')
 const exec = util.promisify(require('child_process').exec)
 
 export default class {
@@ -19,16 +19,14 @@ export default class {
     this.window = window
   }
 
-  private helpers = new Helpers() 
+  private flagPath = 'installer-finished'
 
-  private flagPath = "installer-finished"
-    
-  async getFolderPath(osAndArch: any) {
-    return await this.helpers.getBrowserFolderPath(osAndArch)
+  async getFolderPath() {
+    return await helpers.getBrowserFolderPath()
   }
 
   async isInstalled() {
-    const osAndArch = this.helpers.getOSAndArch()
+    const osAndArch = helpers.getOSAndArch()
 
     const binPath = await this.getBinPath(osAndArch)
     if (fs.existsSync(binPath)) {
@@ -39,7 +37,7 @@ export default class {
 
   getURL(version: unknown, osAndArch: any, language: string, filename: string) {
     if (global.platform.win32) {
-      return "https://github.com/pointnetwork/phyrox-esr-portable/releases/download/test/point-browser-portable-win64-78.12.0-55.7z"
+      return 'https://github.com/pointnetwork/phyrox-esr-portable/releases/download/test/point-browser-portable-win64-78.12.0-55.7z'
     }
     // linux & mac
     return `https://download.cdn.mozilla.net/pub/mozilla.org/firefox/releases/${version}/${osAndArch}/${language}/${filename}`
@@ -62,12 +60,12 @@ export default class {
     console.log('download firefox')
     this.window.webContents.send('firefox:log', 'Installing Firefox...')
 
-    const language = "en-US"
+    const language = 'en-US'
     const version = await this.getLastVersionFirefox() // '93.0b4'//
-    const osAndArch = this.helpers.getOSAndArch()
-    const browserDir = await this.getFolderPath(osAndArch)
+    const osAndArch = helpers.getOSAndArch()
+    const browserDir = await this.getFolderPath()
     const pacFile = url.pathToFileURL(
-      path.join(await this.helpers.getPNPath(osAndArch), "client", "proxy", "pac.js")
+      path.join(await helpers.getPNPath(), 'client', 'proxy', 'pac.js')
     )
     const filename = this.getFileName(osAndArch, version)
     const releasePath = path.join(browserDir, filename)
@@ -78,63 +76,67 @@ export default class {
       fs.mkdirSync(browserDir)
     }
 
-    return https.https.get(firefoxURL, async (response: { pipe: (arg0: fs.WriteStream) => any }) => {
+    return https.https.get(
+      firefoxURL,
+      async (response: { pipe: (arg0: fs.WriteStream) => any }) => {
         await response.pipe(firefoxRelease)
 
         return await new Promise((resolve, reject) => {
-            firefoxRelease.on("finish", () => {
-                const cb = async () => {
-                    fs.unlink(releasePath, (err) => {
-                        if (err) {
-                            return reject(err)
-                        } else {
-                            console.log(`\nDeleted file: ${releasePath}`)
-                            this.window.webContents.send('firefox:log', 'Installed Successfully')
-                            this.launch()
-                            return resolve()
-                        }
-                    })
-
-                    await this.createConfigFiles(osAndArch, pacFile)
-
-                    
+          firefoxRelease.on('finish', () => {
+            const cb = async () => {
+              fs.unlink(releasePath, err => {
+                if (err) {
+                  return reject(err)
+                } else {
+                  console.log(`\nDeleted file: ${releasePath}`)
+                  this.window.webContents.send(
+                    'firefox:log',
+                    'Installed Successfully'
+                  )
+                  this.launch()
+                  return resolve()
                 }
-                this.unpack(osAndArch, releasePath, browserDir, cb)
-            })
+              })
+
+              await this.createConfigFiles(osAndArch, pacFile)
+            }
+            this.unpack(osAndArch, releasePath, browserDir, cb)
+          })
         })
-    })
+      }
+    )
   }
 
   async launch() {
     const isRunning = await find('name', 'Firefox')
-    if(isRunning.length > 0 ) {
+    if (isRunning.length > 0) {
       console.log('Firefox already Running')
       this.window.webContents.send('firefox:log', 'Firefox already Running')
       return
     }
 
-    const osAndArch = this.helpers.getOSAndArch()
+    const osAndArch = helpers.getOSAndArch()
     const cmd = await this.getBinPath(osAndArch)
     const profilePath = path.join(
-      this.helpers.getHomePath(),
-      ".point/keystore/profile"
+      helpers.getHomePath(),
+      '.point/keystore/profile'
     )
-    let webextBinary = ""
+    let webextBinary = ''
     if (global.platform.win32) {
-      webextBinary = "web-ext"
+      webextBinary = 'web-ext'
     } else {
       webextBinary = path.join(
-        this.helpers.getHomePath(),
-        ".point/src/pointnetwork-dashboard/node_modules/web-ext/bin/web-ext"
+        helpers.getHomePath(),
+        '.point/src/pointnetwork-dashboard/node_modules/web-ext/bin/web-ext'
       )
       // webextBinary = 'web-ext'
     }
-    // const webextBinary = path.join(await this.helpers.getHomePath(), ".point/src/pointnetwork-dashboard/node_modules/web-ext/bin/web-ext")
+    // const webextBinary = path.join(await helpers.getHomePath(), ".point/src/pointnetwork-dashboard/node_modules/web-ext/bin/web-ext")
     const extPath = path.join(
-      this.helpers.getHomePath(),
-      ".point/src/pointsdk/dist/prod"
+      helpers.getHomePath(),
+      '.point/src/pointsdk/dist/prod'
     ) // should contain manifest.json
-    let webext = ""
+    let webext = ''
     if (global.platform.win32) {
       webext = `"${webextBinary}" run "--firefox=${cmd}" "--firefox-profile=${profilePath}" --keep-profile-changes "--source-dir=${extPath}" --url https://point`
     } else {
@@ -149,38 +151,38 @@ export default class {
       }
       if (stderr) {
         console.log(`stderr: ${stderr}`)
-        
       }
     })
     this.window.webContents.send('firefox:log', 'Firefox Start')
   }
 
-  unpack(_osAndArch: any, releasePath: string, browserDir: string, cb: { (): Promise<void>; (): void }) {
+  unpack(
+    _osAndArch: any,
+    releasePath: string,
+    browserDir: string,
+    cb: { (): Promise<void>; (): void }
+  ) {
     if (global.platform.win32) {
-      _7z.unpack(releasePath, browserDir, (err) => {
+      _7z.unpack(releasePath, browserDir, err => {
         if (err) throw err
         cb()
       })
     }
     if (global.platform.darwin) {
       dmg.mount(releasePath, (_err: any, dmgPath: any) => {
-        fs.copy(
-          `${dmgPath}/Firefox.app`,
-          `${browserDir}/Firefox.app`,
-          (err) => {
-            if (err) {
-              console.log("Error Found:", err)
-              dmg.unmount(dmgPath, (err: any) => {
-                if (err) throw err
-              })
-              return
-            }
+        fs.copy(`${dmgPath}/Firefox.app`, `${browserDir}/Firefox.app`, err => {
+          if (err) {
+            console.log('Error Found:', err)
             dmg.unmount(dmgPath, (err: any) => {
               if (err) throw err
-              cb()
             })
+            return
           }
-        )
+          dmg.unmount(dmgPath, (err: any) => {
+            if (err) throw err
+            cb()
+          })
+        })
       })
       return
     }
@@ -190,27 +192,27 @@ export default class {
         .pipe(bz2())
         .pipe(tarfs.extract(browserDir))
       // readStream.on('finish', () => {cb()} )
-      readStream.on("finish", cb)
+      readStream.on('finish', cb)
     }
   }
 
   async getRootPath(osAndArch: any) {
     if (global.platform.win32 || global.platform.darwin) {
-      return path.join(await this.getFolderPath(osAndArch))
+      return path.join(await this.getFolderPath())
     }
     // linux
-    return path.join(await this.getFolderPath(osAndArch), "firefox")
+    return path.join(await this.getFolderPath(), 'firefox')
   }
 
   async getAppPath(osAndArch: any) {
     const rootPath = await this.getRootPath(osAndArch)
 
     if (global.platform.win32 || global.platform.darwin) {
-      let appPath = ""
+      let appPath = ''
       if (global.platform.darwin) {
-        appPath = path.join(rootPath, "Firefox.app", "Contents", "Resources")
+        appPath = path.join(rootPath, 'Firefox.app', 'Contents', 'Resources')
       } else {
-        appPath = path.join(rootPath, "app")
+        appPath = path.join(rootPath, 'app')
       }
 
       if (!fs.existsSync(appPath)) {
@@ -228,15 +230,15 @@ export default class {
     const rootPath = await this.getRootPath(osAndArch)
 
     if (global.platform.win32 || global.platform.darwin) {
-      let appPath = ""
+      let appPath = ''
       if (global.platform.darwin) {
-        appPath = path.join(rootPath, "Firefox.app", "Contents", "Resources")
+        appPath = path.join(rootPath, 'Firefox.app', 'Contents', 'Resources')
       } else {
-        appPath = path.join(rootPath, "app")
+        appPath = path.join(rootPath, 'app')
       }
 
-      const defaultsPath = path.join(appPath, "defaults")
-      const prefPath = path.join(defaultsPath, "pref")
+      const defaultsPath = path.join(appPath, 'defaults')
+      const prefPath = path.join(defaultsPath, 'pref')
 
       if (!fs.existsSync(appPath)) {
         fs.mkdirSync(appPath)
@@ -251,30 +253,30 @@ export default class {
       return prefPath
     }
     // linux. all directories already exist.
-    return path.join(rootPath, "defaults", "pref")
+    return path.join(rootPath, 'defaults', 'pref')
   }
 
   async getBinPath(osAndArch: string) {
     const rootPath = await this.getRootPath(osAndArch)
     if (global.platform.win32) {
-      return path.join(rootPath, "point-browser-portable.exe")
+      return path.join(rootPath, 'point-browser-portable.exe')
     }
     if (global.platform.darwin) {
-      return `${path.join(rootPath, "Firefox.app")}`
+      return `${path.join(rootPath, 'Firefox.app')}`
     }
     // linux
-    return path.join(rootPath, "firefox")
+    return path.join(rootPath, 'firefox')
   }
 
   async createConfigFiles(osAndArch: any, pacFile: url.URL) {
     if (!pacFile)
-      throw Error("pacFile sent to createConfigFiles is undefined or null!")
+      throw Error('pacFile sent to createConfigFiles is undefined or null!')
 
-    let networkProxyType = ""
+    let networkProxyType = ''
     if (global.platform.win32) {
-      networkProxyType = "1"
+      networkProxyType = '1'
     }
-    networkProxyType = "2"
+    networkProxyType = '2'
 
     const autoconfigContent = `pref("general.config.filename", "firefox.cfg")
 pref("general.config.obscure_value", 0)
@@ -314,12 +316,11 @@ pref('browser.tabs.drawInTitlebar', true)
       // Portapps also creates `portapps.cfg`, which is equivalent to *nix's firefox.cfg.
       // We're just appending our preferences.
       fs.appendFile(
-        path.join(appPath, "portapps.cfg"),
+        path.join(appPath, 'portapps.cfg'),
         firefoxCfgContent,
-        (err) => {
+        err => {
           if (err) {
             console.error(err)
-            
           }
         }
       )
@@ -330,23 +331,21 @@ pref('browser.tabs.drawInTitlebar', true)
       global.platform.darwin
     ) {
       fs.writeFile(
-        path.join(prefPath, "autoconfig.js"),
+        path.join(prefPath, 'autoconfig.js'),
         autoconfigContent,
-        (err) => {
+        err => {
           if (err) {
             console.error(err)
-            
           }
         }
       )
 
       fs.writeFile(
-        path.join(appPath, "firefox.cfg"),
+        path.join(appPath, 'firefox.cfg'),
         firefoxCfgContent,
-        (err) => {
+        err => {
           if (err) {
             console.error(err)
-            
           }
         }
       )
@@ -355,28 +354,26 @@ pref('browser.tabs.drawInTitlebar', true)
 
   async isFirefoxRanOnce() {
     const pointPath = await module.exports.getPointPath()
-    return fs.pathExistsSync(
-      path.join(pointPath, this.flagPath)
-    )
+    return fs.pathExistsSync(path.join(pointPath, this.flagPath))
   }
 
   async setFirefoxRanOnce() {
     const pointPath = await module.exports.getPointPath()
-    fs.writeFileSync(path.join(pointPath, this.flagPath), "")
+    fs.writeFileSync(path.join(pointPath, this.flagPath), '')
   }
 
   async getLastVersionFirefox() {
-    const url = "https://product-details.mozilla.org/1.0/firefox_versions.json"
+    const url = 'https://product-details.mozilla.org/1.0/firefox_versions.json'
 
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       https.https.get(url, (res: { on: (arg0: string, arg1: any) => void }) => {
-        let data = ""
+        let data = ''
 
-        res.on("data",  (chunk: string) => {
+        res.on('data', (chunk: string) => {
           data += chunk
-         })
+        })
 
-        res.on("end", () => {
+        res.on('end', () => {
           try {
             const json = JSON.parse(data)
             resolve(json.LATEST_FIREFOX_VERSION)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,7 @@
 import installer, { Installer } from '../installer'
-import  dashboard from '../dashboard'
-import { Helpers } from '../../shared/helpers'
+import dashboard from '../dashboard'
+import helpers from '../../shared/helpers'
 ;(async () => {
-  const helpers = new Helpers()
   helpers.getPlatform()
   if (!(await Installer.isInstalled())) {
     installer()


### PR DESCRIPTION
This PR updates the `class Helpers` with functional paradigm and removes certain unused and unnecessary functions as they are either not required or already being handled somewhere else.

The idea is that it doesn't make sense to instantiate the `Helpers` class to be able to use and instead we can simply expose the functions, resulting in a much simpler, easy-to-use and cleaner code.