### PR TITLE
Implement the logic for airdropping a user wallet

### DIFF
--- a/src/dashboard/bridge.ts
+++ b/src/dashboard/bridge.ts
@@ -29,6 +29,9 @@ export const api = {
   nodeStop: () => {
     ipcRenderer.send('node:stop')
   },
+  checkBalanceAndAirdrop: () => {
+    ipcRenderer.send('node:check_balance_and_airdrop')
+  },
 
   on: (channel: string, callback: Function) => {
     ipcRenderer.on(channel, (_, data) => callback(data))

--- a/src/dashboard/ui/App.tsx
+++ b/src/dashboard/ui/App.tsx
@@ -1,16 +1,16 @@
+import { MouseEventHandler } from 'react'
 import Firefox from '../../firefox/ui'
 import Point from '../../node/ui'
 import Grid from '@mui/material/Grid'
 import Box from '@mui/material/Box'
 import { createTheme, ThemeProvider } from '@mui/material/styles'
 import { Button, Container, Typography } from '@mui/material'
-import { MouseEventHandler } from 'react'
 
 const theme = createTheme({
   typography: {
     fontFamily: 'Arial',
-  }
-});
+  },
+})
 
 const logout: MouseEventHandler = () => {
   window.Dashboard.logOut()
@@ -19,13 +19,12 @@ const logout: MouseEventHandler = () => {
 export default function App() {
   return (
     <ThemeProvider theme={theme}>
-      <Container maxWidth="md" sx={{marginTop:'5px'}}>
-
+      <Container maxWidth="md" sx={{ marginTop: '5px' }}>
         <Grid container spacing={2}>
           <Grid item xs={10}>
-          <Typography variant="h4" gutterBottom component="div">
-            Welcome to the Point Dashboard
-          </Typography>
+            <Typography variant="h4" gutterBottom component="div">
+              Welcome to the Point Dashboard
+            </Typography>
           </Grid>
           <Grid item xs={2}>
             <Button variant="outlined" onClick={logout}>

--- a/src/node/ui/index.tsx
+++ b/src/node/ui/index.tsx
@@ -11,6 +11,7 @@ export default function () {
     window.Dashboard.on('pointNode:checked', (active: boolean) => {
       const color = active ? 'green' : 'red'
       setIsPointNodeActive(color)
+      window.Dashboard.checkBalanceAndAirdrop()
     })
   }, [])
 

--- a/src/node/ui/index.tsx
+++ b/src/node/ui/index.tsx
@@ -8,10 +8,13 @@ export default function () {
   const [isPointNodeActive, setIsPointNodeActive] = useState<string>()
 
   useEffect(() => {
+    checkNode()
     window.Dashboard.on('pointNode:checked', (active: boolean) => {
       const color = active ? 'green' : 'red'
       setIsPointNodeActive(color)
-      window.Dashboard.checkBalanceAndAirdrop()
+      setTimeout(() => {
+        active && window.Dashboard.checkBalanceAndAirdrop()
+      }, 5000)
     })
   }, [])
 


### PR DESCRIPTION
This PR is still a work in progress. The logic to airdrop a user wallet is perfectly working. The only problem is that we need to make sure PointNode is actually started before requesting the airdrop because PointNode returns use the user wallet address, and only after that we should make the Airdrop request. This thing needs to be taken care of. This problem though right now is very very very useful to test the airdrop thing.

### To test the functionality -
0. Logout if you are already logged in and close everything related to point-node/dashboard
1. Restart the dashboard and generate a new key
2. Do **NOT** interact with the dashboard at all!! Allow Firefox to startup and navigate to `https://twitter.z`
3. Try to like a tweet, it'll give a 500 error for not having sufficient funds
4. Now navigate back to the Point Dashboard. click `Check Status` for the Point Node. This will do some magic and call the airdrop request to check if you have balance or not, else it'll add 1 yPoint to the wallet address
5. Now again try to like a post in `twitter.z` and it'll work fine

### Why such behavior
We need to allow the Point to first fire up before receiving the request. This is something that I'll look into within this PR only.

### A Known Issue Scenario
That current check compares user wallet balance against literally `0`. Let's assume that I have `.001` balance in my wallet, but it takes `0.0011` to do anything in the Point Network. Then in that case we cannot airdrop the user since balance never gets `0`. We can have some buffer before issuing a yPoint from the faucet. **TBD**