### PR TITLE
Add workflow to build electron executable for all platforms

### DIFF
--- a/.github/workflows/electron-builder.yml
+++ b/.github/workflows/electron-builder.yml
@@ -1,0 +1,113 @@
+name: Build
+on:
+  push:
+    # tags:
+    #   - 'v*'
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+      release_name: ${{ steps.get_source_tag.outputs.SOURCE_TAG }}
+    steps:
+    - name: Get the Source Tag
+      id: get_source_tag
+      run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.get_source_tag.outputs.SOURCE_TAG }}
+        release_name: Release ${{ steps.get_source_tag.outputs.SOURCE_TAG }}
+        draft: false
+        prerelease: false
+
+  build_on_linux:
+    runs-on: ubuntu-latest
+    needs: create_release
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@master
+      with:
+        node-version: 14
+    - name: Install dependencies
+      run: npm install
+    - name: Build executables
+      run: npm run make
+
+    - name: Compress and package executables
+      run: ./scripts/package_linux_executables.sh
+
+    - name: Upload linux deb artefact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.release_upload_url }}
+        asset_path: ./out/linux_executables/point-dashboard-deb.tar.gz
+        asset_name: point-dashboard-${{ needs.create_release.outputs.release_name }}-deb.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload linux rpm artefact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.release_upload_url }}
+        asset_path: ./out/linux_executables/point-dashboard-rpm.tar.gz
+        asset_name: point-dashboard-${{ needs.create_release.outputs.release_name }}-rpm.tar.gz
+        asset_content_type: application/gzip
+
+  build_on_mac:
+    runs-on: macos-latest
+    needs: create_release
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@master
+      with:
+        node-version: 14
+    - name: Install dependencies
+      run: npm install
+    - name: Build executables
+      run: npm run make
+
+    - name: Compress and package executables
+      run: ./scripts/package_macos_executables.sh
+    - name: Upload macos artefact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.release_upload_url }}
+        asset_path: ./out/mac_executables/point-dashboard.tar.gz
+        asset_name: point-dashboard-${{ needs.create_release.outputs.release_name }}-mac.tar.gz
+        asset_content_type: application/gzip
+
+  build_on_win:
+    runs-on: windows-latest
+    needs: create_release
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@master
+      with:
+        node-version: 14
+    - name: Update npm
+      run: npm i -g npm
+    - name: Install dependencies
+      run: npm install
+    - name: Build executables
+      run: npm run make
+
+    - name: Compress and package executables
+      run: bash ./scripts/package_win_executables.sh
+    - name: Upload win artefact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.release_upload_url }}
+        asset_path: ./out/win_executables/point-dashboard.tar.gz
+        asset_name: point-dashboard-${{ needs.create_release.outputs.release_name }}-win.tar.gz
+        asset_content_type: application/gzip

--- a/scripts/package_linux_executables.sh
+++ b/scripts/package_linux_executables.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script will rename, add execution permissions and compress point executables.
+
+VERSION=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
+
+DEB_FILE=./out/make/deb/x64/pointnetwork-dashboard_"$VERSION"_amd64.deb
+RPM_FILE=./out/make/rpm/x64/pointnetwork-dashboard-"$VERSION"-1.x86_64.rpm
+
+mkdir -p ./out/linux_executables
+
+mv $DEB_FILE ./out/linux_executables/point-dashboard.deb
+mv $RPM_FILE ./out/linux_executables/point-dashboard.rpm
+
+for FILE in ./out/linux_executables/*; do
+  chmod +x $FILE
+  tmp=${FILE#*-};
+  EXTENSION=${tmp#*\.};
+  mkdir -p ./out/linux_executables/$EXTENSION;
+  mv $FILE ./out/linux_executables/$EXTENSION;
+  tar -czvf ./out/linux_executables/point-dashboard-$EXTENSION.tar.gz -C ./out/linux_executables/$EXTENSION ./;
+done

--- a/scripts/package_macos_executables.sh
+++ b/scripts/package_macos_executables.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script will rename, add execution permissions and compress point executables.
+
+MAC_FILE=./out/pointnetwork-dashboard-darwin-x64/pointnetwork-dashboard.app
+
+mkdir -p ./out/mac_executables/pkg
+chmod +x $MAC_FILE
+mv $MAC_FILE ./out/mac_executables/pkg/point-dashboard.app
+tar -czvf ./out/mac_executables/point-dashboard.tar.gz -C ./out/mac_executables/pkg ./

--- a/scripts/package_win_executables.sh
+++ b/scripts/package_win_executables.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will rename, add execution permissions and compress point executables.
+
+VERSION=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
+
+DEB_FILE=./out/make/deb/x64/pointnetwork-dashboard_"$VERSION"_amd64.deb
+
+WIN_FILE="./out/make/squirrel.windows/x64/pointnetwork-dashboard-${VERSION} Setup.exe"
+
+mkdir -p ./out/win_executables/pkg
+chmod +x "$WIN_FILE"
+mv "$WIN_FILE" ./out/win_executables/pkg/point-dashboard.exe
+tar -czvf ./out/win_executables/point-dashboard.tar.gz -C ./out/win_executables/pkg ./

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// - Leverages `npm version` script which creates a new tag
+// - Updates package.json, adding this new version
+// - Pushes the tag to the repository
+
+const version = process.argv[2];
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+        `Unsupported version format: "${version}". ` +
+            `Please provide a unique sequence of major, minor and build version identifiers.`
+    );
+}
+
+const {execSync} = require('child_process');
+
+try {
+    execSync(`npm version ${version}`).toString();
+    execSync(`git push && git push origin v${version}`).toString();
+    console.info(`Successfully pushed new addon version "v${version}".`);
+} catch (e) {
+    console.error(
+        (e.stderr && e.stderr.toString()) || (e.stdout && e.stdout.toString()) || e.toString()
+    );
+    throw e;
+}


### PR DESCRIPTION
It builds electron executable for linux, mac and windows platforms on new releases and attaches those executables as artefacts of the new release.