### PR TITLE
Fix the Object destroyed and multiple windows errors + close the node after logout

### DIFF
--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -6,7 +6,8 @@ import axios from 'axios'
 
 let mainWindow: BrowserWindow | null
 
-let node: Node
+let node: Node | null
+let firefox: Firefox | null
 
 declare const DASHBOARD_WINDOW_PRELOAD_WEBPACK_ENTRY: string
 declare const DASHBOARD_WINDOW_WEBPACK_ENTRY: string
@@ -17,7 +18,7 @@ declare const DASHBOARD_WINDOW_WEBPACK_ENTRY: string
 //     : app.getAppPath()
 
 export default function (isExplicitRun = false) {
-  function createWindow() {
+  async function createWindow() {
     mainWindow = new BrowserWindow({
       // icon: path.join(assetsPath, 'assets', 'icon.png'),
       width: 860,
@@ -29,64 +30,98 @@ export default function (isExplicitRun = false) {
         preload: DASHBOARD_WINDOW_PRELOAD_WEBPACK_ENTRY,
       },
     })
+
     node = new Node(mainWindow!)
+    if (!(await node.pointNodeCheck())) node.launch()
+
+    firefox = new Firefox(mainWindow!)
     // debug
     // mainWindow.webContents.openDevTools()
 
     mainWindow.loadURL(DASHBOARD_WINDOW_WEBPACK_ENTRY)
 
-    mainWindow.on('closed', () => {
+    mainWindow.on('close', async () => {
       console.log('Closed Dashboard Window')
+      events.forEach(event => {
+        ipcMain.removeListener(event.channel, event.listener)
+        console.log('[dashboard:index.ts] Removed event', event.channel)
+      })
+      await node?.stopNode()
+    })
+
+    mainWindow.on('closed', () => {
+      node = null
+      firefox = null
       mainWindow = null
     })
   }
 
-  async function registerListeners() {
-    const firefox = new Firefox(mainWindow!)
-
-    ipcMain.on('firefox:launch', async (_, message) => {
-      await firefox.launch()
-    })
-
-    ipcMain.on('node:launch', async (_, message) => {
-      node.launch()
-    })
-
-    ipcMain.on('node:check', async (_, message) => {
-      await node.pointNodeCheck()
-    })
-
-    ipcMain.on('logOut', async (_, message) => {
-      mainWindow!.close()
-      helpers.logout()
-    })
-
-    ipcMain.on('node:stop', async (_, message) => {
-      node.stopNode()
-    })
-
-    ipcMain.on('node:check_balance_and_airdrop', async () => {
-      try {
-        console.log('[node:check_balance_and_airdrop] Getting wallet address')
-        let res = await axios.get('http://localhost:2468/v1/api/wallet/address')
-        const address = res.data.data.address
-        console.log(
-          `[node:check_balance_and_airdrop] Getting wallet balance for address: ${address}`
-        )
-        res = await axios.get(
-          `https://point-faucet.herokuapp.com/balance?address=${address}`
-        )
-        if (res.data.balance <= 0) {
+  const events = [
+    {
+      channel: 'firefox:launch',
+      listener() {
+        firefox!.launch()
+      },
+    },
+    {
+      channel: 'node:launch',
+      listener() {
+        node!.launch()
+      },
+    },
+    {
+      channel: 'node:check',
+      listener() {
+        node!.pointNodeCheck()
+      },
+    },
+    {
+      channel: 'logOut',
+      listener() {
+        mainWindow!.close()
+        helpers.logout()
+      },
+    },
+    {
+      channel: 'node:stop',
+      async listener() {
+        await node!.stopNode()
+      },
+    },
+    {
+      channel: 'node:check_balance_and_airdrop',
+      async listener() {
+        try {
+          console.log('[node:check_balance_and_airdrop] Getting wallet address')
+          let res = await axios.get(
+            'http://localhost:2468/v1/api/wallet/address'
+          )
+          const address = res.data.data.address
           console.log(
-            '[node:check_balance_and_airdrop] Airdropping wallet address with yPoints'
+            `[node:check_balance_and_airdrop] Getting wallet balance for address: ${address}`
           )
-          await axios.get(
-            `https://point-faucet.herokuapp.com/airdrop?address=${address}`
+          res = await axios.get(
+            `https://point-faucet.herokuapp.com/balance?address=${address}`
           )
+          if (res.data.balance <= 0) {
+            console.log(
+              '[node:check_balance_and_airdrop] Airdropping wallet address with yPoints'
+            )
+            await axios.get(
+              `https://point-faucet.herokuapp.com/airdrop?address=${address}`
+            )
+          }
+        } catch (error) {
+          console.error(error)
         }
-      } catch (error) {
-        console.error(error)
-      }
+      },
+    },
+  ]
+
+  async function registerListeners() {
+    events.forEach(event => {
+      ipcMain.on(event.channel, event.listener)
+      console.log('[dashboard:index.ts] Registered event', event.channel)
     })
   }
 
@@ -99,7 +134,6 @@ export default function (isExplicitRun = false) {
     // This is a good place to add tests insuring the app is still
     // responsive and all windows are closed.
     console.log('Dashboard Window "will-quit" event')
-    await node.stopNode()
   })
 
   if (!isExplicitRun) {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -20,7 +20,6 @@ export default class Node {
   constructor(window: BrowserWindow) {
     this.window = window
     this.installationLogger = new Logger({ window, channel: 'installer' })
-    this.getNodeProcess()
   }
 
   getURL(filename: string) {
@@ -127,16 +126,14 @@ export default class Node {
 
     exec(cmd, (error: { message: any }, _stdout: any, stderr: any) => {
       console.log('Launched Node')
-      this.window.webContents.send('pointNode:checked', true)
       if (error) {
         console.log(`pointnode launch exec error: ${error.message}`)
-        this.window.webContents.send('pointNode:checked', false)
       }
       if (stderr) {
         console.log(`pointnode launch exec stderr: ${stderr}`)
-        this.window.webContents.send('pointNode:checked', false)
       }
     })
+    this.getNodeProcess()
   }
 
   pointNodeCheck(): boolean {
@@ -153,17 +150,14 @@ export default class Node {
   }
 
   async getNodeProcess() {
-    if (await this.isInstalled()) {
-      await this.launch()
-      console.log('Checking PointNode PID')
-      const process = await find('name', 'point', true)
-      if (process.length > 0) {
-        console.log('Found running process', process)
-        this.pid = process[0].pid
-        console.log('Process ID', this.pid)
-        this.killCmd = `kill ${this.pid}`
-        if (global.platform.win32) this.killCmd = `taskkill /F /PID ${this.pid}`
-      }
+    console.log('Checking PointNode PID')
+    const process = await find('name', 'point', true)
+    if (process.length > 0) {
+      console.log('Found running process', process)
+      this.pid = process[0].pid
+      console.log('Process ID', this.pid)
+      this.killCmd = `kill ${this.pid}`
+      if (global.platform.win32) this.killCmd = `taskkill /F /PID ${this.pid}`
     }
   }
 

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -1,7 +1,9 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
 import WelcomeService from './services'
 import dashboard from '../dashboard'
+
 let mainWindow: BrowserWindow | null
+let welcomeService: WelcomeService | null
 
 declare const WELCOME_WINDOW_PRELOAD_WEBPACK_ENTRY: string
 declare const WELCOME_WINDOW_WEBPACK_ENTRY: string
@@ -27,31 +29,52 @@ export default function (isExplicitRun = false) {
 
     // debug
     //  mainWindow.webContents.openDevTools()
+    welcomeService = new WelcomeService(mainWindow!)
 
     mainWindow.loadURL(WELCOME_WINDOW_WEBPACK_ENTRY)
 
+    mainWindow.on('close', () => {
+      console.log('Closed Welcome Window')
+      events.forEach(event => {
+        ipcMain.removeListener(event.channel, event.listener)
+        console.log('[welcome:index.ts] Removed event', event.channel)
+      })
+    })
     mainWindow.on('closed', () => {
       mainWindow = null
+      welcomeService = null
     })
   }
 
+  const events = [
+    {
+      channel: 'welcome:generate_mnemonic',
+      listener() {
+        welcomeService!.generate()
+      },
+    },
+    {
+      channel: 'welcome:validate_mnemonic',
+      listener(_: any, message: string) {
+        welcomeService!.validate(message.replace(/^\s+|\s+$/g, ''))
+      },
+    },
+    {
+      channel: 'welcome:login',
+      async listener(_: any, message: string) {
+        const result = await welcomeService!.login(message)
+        if (result) {
+          dashboard(true)
+          welcomeService!.close()
+        }
+      },
+    },
+  ]
+
   async function registerListeners() {
-    const welcomeService = new WelcomeService(mainWindow!)
-
-    ipcMain.on('welcome:generate_mnemonic', async (_, message) => {
-      welcomeService.generate()
-    })
-
-    ipcMain.on('welcome:validate_mnemonic', async (_, message) => {
-      welcomeService.validate(message.replace(/^\s+|\s+$/g, ''))
-    })
-
-    ipcMain.on('welcome:login', async (_, message) => {
-      const result = await welcomeService.login(message)
-      if (result) {
-        dashboard(true)
-        welcomeService.close()
-      }
+    events.forEach(event => {
+      ipcMain.on(event.channel, event.listener)
+      console.log('[welcome:index.ts] Registered event', event.channel)
     })
   }
 


### PR DESCRIPTION
This PR fixes multiple issues that we had with the dashboard.
- Fixes the `Object destroyed` errors that we had
- Fixes multiple window instances being generated when logging out and logging in again
- Stops the Node after each logout and creates a new session for when logging back in

The `Object destroyed` and multiple windows errors are fixed by unregistering the event listeners on `ipcMain` after the window is closed and destroying the references to the different class instances that we have (`Node`, `Firefox`, etc).

## IMPORTANT!

The easiest way to test the behavior that whether the Node actually closes after a logout is to use a web browser and hit the `http://localhost:2468/v1/api/wallet/address` endpoint.
- Login with some key and hit the endpoint. You'll get the address related to that key.
- Click Logout button. This will ideally close the Node
- Now try to hit the above URL once again. Ideally it should fail as Node has shutdown, if not REPORT IMMEDIATELY.
- Now use a different key to login back into the dashboard
- Again, hit the above URL and you should see a different address. If not, then that means the Node did not shut down, again REPORT IMMEDIATELY.