### PR TITLE
Fix update version script to reference HEAD:develop

### DIFF
--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -17,7 +17,7 @@ const {execSync} = require('child_process');
 
 try {
     execSync(`npm version ${version}`).toString();
-    execSync(`git push && git push origin v${version}`).toString();
+    execSync(`git push origin HEAD:develop && git push origin v${version}`).toString();
     console.info(`Successfully pushed new addon version "v${version}".`);
 } catch (e) {
     console.error(


### PR DESCRIPTION
For some reason another reference to develop was created generating an error and collision when a new release needs to be pushed to develop branch. This changes addresses that issue.