### PR TITLE
PD-73 Make installer window non-resizable.

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -26,6 +26,8 @@ export default function () {
         contextIsolation: true,
         preload: INSTALLER_WINDOW_PRELOAD_WEBPACK_ENTRY,
       },
+      resizable: false,
+      maximizable: false,
     })
 
     installer = new Installer(mainWindow!)


### PR DESCRIPTION
Prevent installer window to be resized or maximized.

I tested on Linux and it's working as expected. I'll set up a VM tonight so I can test more complex changes on Windows as well. This is a simple change and should work fine, but if someone could check MacOS and Windows, that'd be awesome. Thanks.