### PR TITLE
PD-70 Close browser on dashboard close and logout

### DIFF
--- a/src/@types/process.ts
+++ b/src/@types/process.ts
@@ -1,0 +1,9 @@
+export type Process = {
+  pid: number
+  ppid?: number
+  uid?: number
+  gid?: number
+  name: string
+  bin?: string
+  cmd: string
+}

--- a/src/dashboard/bridge.ts
+++ b/src/dashboard/bridge.ts
@@ -23,6 +23,9 @@ export const api = {
   openFirefox: () => {
     ipcRenderer.send('firefox:launch')
   },
+  changeFirefoxStatus: (isRunning: boolean) => {
+    ipcRenderer.send('firefox:status', isRunning)
+  },
   nodeStop: () => {
     ipcRenderer.send('node:stop')
   },

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -11,6 +11,7 @@ let node: Node | null
 let firefox: Firefox | null
 
 let isFirefoxRunning = false
+let isLoggingOut = false
 
 declare const DASHBOARD_WINDOW_PRELOAD_WEBPACK_ENTRY: string
 declare const DASHBOARD_WINDOW_WEBPACK_ENTRY: string
@@ -44,6 +45,8 @@ export default function (isExplicitRun = false) {
       },
     })
 
+    isLoggingOut = false
+
     node = new Node(mainWindow!)
     // if (!(await node.pointNodeCheck())) node.launch()
 
@@ -56,7 +59,7 @@ export default function (isExplicitRun = false) {
     mainWindow.on('close', async ev => {
       let quit = true
 
-      if (isFirefoxRunning) {
+      if (!isLoggingOut && isFirefoxRunning) {
         const confirmationAnswer = dialog.showMessageBoxSync({
           type: 'question',
           title: MESSAGES.closeConfirmation.title,
@@ -132,7 +135,8 @@ export default function (isExplicitRun = false) {
     {
       channel: 'logOut',
       async listener() {
-        await Promise.all([firefox!.close(), node!.stopNode()])
+        isLoggingOut = true
+        await node!.stopNode()
         helpers.logout()
         mainWindow!.close()
       },

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -67,7 +67,7 @@ export default function (isExplicitRun = false) {
 
     mainWindow.on('close', async ev => {
       // We prevent default to programatically close the window,
-      // thus ensuring we await for all necessaries actions to complete.
+      // thus ensuring we await for all necessary actions to complete.
       ev.preventDefault()
 
       let quit = true

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -79,8 +79,7 @@ export default function (isExplicitRun = false) {
           ipcMain.removeListener(event.channel, event.listener)
           console.log('[dashboard:index.ts] Removed event', event.channel)
         })
-        await firefox?.close()
-        await node?.stopNode()
+        await Promise.all([firefox?.close(), node?.stopNode()])
       } else {
         ev.preventDefault()
       }
@@ -133,7 +132,7 @@ export default function (isExplicitRun = false) {
     {
       channel: 'logOut',
       async listener() {
-        await node!.stopNode()
+        await Promise.all([firefox!.close(), node!.stopNode()])
         helpers.logout()
         mainWindow!.close()
       },

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -26,6 +26,15 @@ const MESSAGES = {
       cancel: 'No',
     },
   },
+  logoutConfirmation: {
+    title: 'Are you sure you want to log out?',
+    message:
+      'Do you want to close the browser and remove the secret phrase from this computer?',
+    buttons: {
+      confirm: 'Yes',
+      cancel: 'No',
+    },
+  },
 }
 
 // const assetsPath =
@@ -135,10 +144,23 @@ export default function (isExplicitRun = false) {
     {
       channel: 'logOut',
       async listener() {
-        isLoggingOut = true
-        await node!.stopNode()
-        helpers.logout()
-        mainWindow!.close()
+        const confirmationAnswer = dialog.showMessageBoxSync({
+          type: 'question',
+          title: MESSAGES.logoutConfirmation.title,
+          message: MESSAGES.logoutConfirmation.message,
+          buttons: [
+            MESSAGES.logoutConfirmation.buttons.confirm,
+            MESSAGES.logoutConfirmation.buttons.cancel,
+          ],
+        })
+
+        if (confirmationAnswer === 0) {
+          // User clicked 'Yes' (button at index 0)
+          isLoggingOut = true
+          await node!.stopNode()
+          helpers.logout()
+          mainWindow!.close()
+        }
       },
     },
     {

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -79,6 +79,7 @@ export default function (isExplicitRun = false) {
           ipcMain.removeListener(event.channel, event.listener)
           console.log('[dashboard:index.ts] Removed event', event.channel)
         })
+        await firefox?.close()
         await node?.stopNode()
       } else {
         ev.preventDefault()

--- a/src/dashboard/ui/App.tsx
+++ b/src/dashboard/ui/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
 
     window.Dashboard.on('firefox:active', (status: boolean) => {
       setIsFirefoxRunning(status)
+      window.Dashboard.changeFirefoxStatus(status)
     })
 
     window.Dashboard.on('pointNode:checked', (version: string | null) => {

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -8,9 +8,11 @@ import util from 'util'
 import https from 'follow-redirects'
 import { BrowserWindow } from 'electron'
 import Logger from '../../shared/logger'
+import type { Process } from '../@types/process'
 
 const dmg = require('dmg')
 const bz2 = require('unbzip2-stream')
+const find = require('find-process')
 const exec = util.promisify(require('child_process').exec)
 
 export default class {
@@ -140,6 +142,26 @@ export default class {
       if (stderr) this.window.webContents.send('firefox:active', false)
     } catch (error) {
       this.window.webContents.send('firefox:active', false)
+    }
+  }
+
+  getKillCmd(pid: number) {
+    return global.platform.win32 ? `taskkill /F /PID ${pid}` : `kill ${pid}`
+  }
+
+  async close() {
+    const processes: Process[] = await find('name', /firefox/i)
+
+    const pointBrowserParentProcesses = processes.filter(
+      p => p.cmd.includes('point-browser') && !p.cmd.includes('tab')
+    )
+
+    if (pointBrowserParentProcesses.length > 0) {
+      for (const p of pointBrowserParentProcesses) {
+        console.log(`[firefox:close] Killing PID ${p.pid}...`)
+        const cmdOutput = await exec(this.getKillCmd(p.pid))
+        console.log(`[firefox:close] Output of "kill ${p.pid}":`, cmdOutput)
+      }
     }
   }
 


### PR DESCRIPTION
There are two scenarios when the Point Browser should be closed:

1. Closing the Dashboard
2. Logging out

In both cases, we present the user with a confirmation dialog (please double check the wording). Note that if the browser is not open when trying to close the dashboard, the confirmation dialog will not be shown as it wouldn't make sense.

Should the user have other instances of Firefox open, they should remain unaffected, only the "Point Browser Firefox" should be closed.

PS: formatting changes were applied when running prettier.