### PR TITLE
PD-94 Fix error about checkNodeVersion

### DIFF
--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -57,6 +57,7 @@ export default function (isExplicitRun = false) {
     isLoggingOut = false
 
     node = new Node(mainWindow!)
+    await node.checkNodeVersion()
     // if (!(await node.pointNodeCheck())) node.launch()
 
     firefox = new Firefox(mainWindow!)

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -2,7 +2,6 @@ import { app, BrowserWindow, ipcMain } from 'electron'
 import welcome from '../welcome'
 import baseWindowConfig from '../../shared/windowConfig'
 import Installer from './service'
-import helpers from '../../shared/helpers'
 export { Installer }
 
 app.disableHardwareAcceleration()
@@ -43,9 +42,6 @@ export default function () {
       mainWindow = null
       installer = null
     })
-    
-    Installer.checkNodeVersion()
-  
   }
 
   const events = [
@@ -65,13 +61,15 @@ export default function () {
       console.log('[installer:index.ts] Registered event', event.channel)
     })
     ipcMain.on('installer:checkUpdate', async (_, message) => {
-      new Installer(mainWindow!).checkUpdateOrInstall()
+      console.log(
+        '[installer:index.ts] TODO!! -> implement checkUpdateOrInstall method'
+      )
+      // new Installer(mainWindow!).checkUpdateOrInstall()
     })
-    
   }
 
   app
-    .on('ready', createWindow, )
+    .on('ready', createWindow)
     .whenReady()
     .then(registerListeners)
     .catch(e => console.error(e))


### PR DESCRIPTION
Upon creation of the Installer window, we were calling `Installer.checkNodeVersion()`, but `checkNodeVersion` is a method of `Node`, not of `Installer`.

Based on the reasons below, I don't think we need to check Node version on the installer, and that we could check it on the Dashboard.

1. The `checkNodeVersion` is a method of `Node`, which gets instantiated by the Dashboard.
2. It has logic to stop the running `node`.
3. It sends a `node:update` message, which gets handled by the [Dashboard UI](https://github.com/pointnetwork/pointnetwork-dashboard/blob/develop/src/dashboard/ui/App.tsx#L31-L39).

But I may be missing something, so please let me know if we should check the Node version on the Installer.

With these changes, I don't see the error described in the ticket anymore, and the Node and Browser are launched successfully.
![Screenshot from 2022-03-14 09-52-38](https://user-images.githubusercontent.com/101118664/158177857-0fa540fb-63b8-4a78-8404-bf26f20bf77c.png)

