### PR TITLE
Fix icon on linux.

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,11 +158,15 @@
         },
         {
           "name": "@electron-forge/maker-deb",
-          "config": {}
+          "config": {
+            "icon": "assets/icon.png"
+          }
         },
         {
           "name": "@electron-forge/maker-rpm",
-          "config": {}
+          "config": {
+            "icon": "assets/icon.png"
+          }
         }
       ]
     }


### PR DESCRIPTION
Tested on an Ubuntu VM, installing the _.deb_ package, and the correct icon is displayed.
![ubuntu1](https://user-images.githubusercontent.com/101118664/158227940-ffc660e3-d795-4c29-b896-dd7c2ff051b9.jpeg)
![ubuntu2](https://user-images.githubusercontent.com/101118664/158227965-e2760f8a-a2f7-4276-9353-d78a05898abb.jpeg)

