### PR TITLE
PD-117 Download Firefox from phyrox-esr-portable [Windows].

### DIFF
--- a/src/@types/github-release.ts
+++ b/src/@types/github-release.ts
@@ -1,0 +1,11 @@
+export type GithubRelease = {
+  id: number
+  url: string
+  tag_name: string // eslint-disable-line camelcase
+  name: string
+  assets: Array<{
+    id: number
+    name: string
+    browser_download_url: string // eslint-disable-line camelcase
+  }>
+}


### PR DESCRIPTION
Download Firefox from our fork of phyrox-esr-portable.

It makes a request to the GitHub API to get the latest release from that repo. According to GitHub docs, it will not fetch _drafts_ nor _prereleases_, so I think it's safe to use. If this call fails for any reason, we use a hard-coded version.

I tested on a Windows VM and confirmed that the Firefox version we install is the one from phyrox-esr-portable.