### PR TITLE
Feature/dashboard update link

### DIFF
--- a/shared/helpers.ts
+++ b/shared/helpers.ts
@@ -43,19 +43,23 @@ const getPlatform = () => {
   }
 }
 
-const getlatestReleaseVersion = async () => {
-  const url =
-    'https://api.github.com/repos/pointnetwork/pointnetwork/releases/latest'
-  const headers = { 'user-agent': 'node.js' }
-  const res = await axios.get(url, {
-    headers: headers,
-  })
+const getlatestNodeReleaseVersion = async () => {
+  try {
+    const url =
+      'https://api.github.com/repos/pointnetwork/pointnetwork/releases/latest'
+    const headers = { 'user-agent': 'node.js' }
+    const res = await axios.get(url, {
+      headers: headers,
+    })
 
-  console.log('last version', res.data.tag_name)
-  return res.data.tag_name
+    console.log('Lastest Node version', res.data.tag_name)
+    return res.data.tag_name
+  } catch (error) {
+    console.error(error)
+  }
 }
 
-const getPortableDownloadURL = async () => {
+const getPortableDashboardDownloadURL = async () => {
   return 'https://github.com/pointnetwork/pointnetwork-dashboard/releases/download/v0.1.0/point-browser.zip'
   const owner = 'pointnetwork'
   const repo = 'phyrox-esr-portable'
@@ -98,18 +102,6 @@ const getHomePath = () => {
   return os.homedir()
 }
 
-const getPNPath = () => {
-  return path.join(getHomePath(), '.point', 'src', 'pointnetwork')
-}
-
-const getDashboardPath = () => {
-  return path.join(getHomePath(), '.point', 'src', 'pointnetwork-dashboard')
-}
-
-const getSDKPath = () => {
-  return path.join(getHomePath(), '.point', 'src', 'pointsdk')
-}
-
 const getBrowserFolderPath = () => {
   const browserDir = path.join(getHomePath(), '.point', 'src', 'point-browser')
   if (!fs.existsSync(browserDir)) {
@@ -138,13 +130,11 @@ const isLoggedIn = () => {
   return fs.existsSync(getKeyFileName())
 }
 
-const getInstalledVersion = () => {
+const getInstalledNodeVersion = () => {
   const pointPath = getPointPath()
   try {
     const versionData = fs.readFileSync(path.join(pointPath, 'infoNode.json'))
-    const version = versionData.toString()
-    const installedVersion = JSON.parse(version)
-    return installedVersion
+    return JSON.parse(versionData.toString())
   } catch (error) {
     return {
       installedReleaseVersion: 'old',
@@ -173,18 +163,6 @@ const getPointSrcPath = () => {
 
 const getPointSoftwarePath = () => {
   return path.join(getPointPath(), 'software')
-}
-
-const isPNCloned = () => {
-  return fs.existsSync(getPNPath())
-}
-
-const isDashboardCloned = () => {
-  return fs.existsSync(getDashboardPath())
-}
-
-const isSDKCloned = () => {
-  return fs.existsSync(getSDKPath())
 }
 
 const copyFileSync = (source: string, target: string) => {
@@ -249,15 +227,43 @@ const countFilesinDir = async (dir: string): Promise<number> => {
   return fileCount
 }
 
+const getInstalledDashboardVersion = () => {
+  const pjson = require('../package.json')
+  return pjson.version
+}
+
+const isNewDashboardReleaseAvailable = async () => {
+  try {
+    const url =
+      'https://api.github.com/repos/pointnetwork/pointnetwork-dashboard/releases/latest'
+    const headers = { 'user-agent': 'node.js' }
+    const res = await axios.get(url, {
+      headers: headers,
+    })
+    const latestVersion = res.data.tag_name
+
+    if (latestVersion.slice(1) > getInstalledDashboardVersion()) {
+      return {
+        isUpdateAvailable: true,
+        latestVersion,
+      }
+    }
+
+    return {
+      isUpdateAvailable: false,
+      latestVersion,
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
 export default Object.freeze({
   noop,
   getOSAndArch,
   getPlatform,
   getHTTPorHTTPs,
   fixPath,
-  getPNPath,
-  getDashboardPath,
-  getSDKPath,
   getBrowserFolderPath,
   getHomePath,
   getLiveDirectoryPath,
@@ -267,16 +273,15 @@ export default Object.freeze({
   logout,
   getPointSrcPath,
   getPointSoftwarePath,
-  isPNCloned,
-  isDashboardCloned,
-  isSDKCloned,
   getBinPath,
   copyFileSync,
   copyFolderRecursiveSync,
   getPointPath,
-  getlatestReleaseVersion,
-  getInstalledVersion,
+  getlatestNodeReleaseVersion,
+  getInstalledNodeVersion,
   getLiveDirectoryPathResources,
   countFilesinDir,
-  getPortableDownloadURL,
+  getPortableDashboardDownloadURL,
+  getInstalledDashboardVersion,
+  isNewDashboardReleaseAvailable,
 })

--- a/src/dashboard/bridge.ts
+++ b/src/dashboard/bridge.ts
@@ -26,6 +26,9 @@ export const api = {
   getDashboardVersion: () => {
     ipcRenderer.send('node:getDashboardVersion')
   },
+  isNewDashboardReleaseAvailable: () => {
+    ipcRenderer.send('dashboard:isNewDashboardReleaseAvailable')
+  },
   changeFirefoxStatus: (isRunning: boolean) => {
     ipcRenderer.send('firefox:status', isRunning)
   },
@@ -42,7 +45,10 @@ export const api = {
     ipcRenderer.send('node:check_balance_and_airdrop')
   },
   getNodeVersion: (): string => {
-    return ipcRenderer.sendSync('node:getVersion');
+    return ipcRenderer.sendSync('node:getVersion')
+  },
+  openDashboardDownloadLink: (url: string) => {
+    ipcRenderer.send('dashboard:openDownloadLink', url)
   },
 
   on: (channel: string, callback: Function) => {

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -49,7 +49,7 @@ export default class {
   }
 
   async getURLWindows() {
-    const url = await helpers.getPortableDownloadURL()
+    const url = await helpers.getPortableDashboardDownloadURL()
     return url
   }
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -66,7 +66,7 @@ export default class Node {
   download = () =>
     // eslint-disable-next-line no-async-promise-executor
     new Promise(async (resolve, reject) => {
-      const version = await helpers.getlatestReleaseVersion()
+      const version = await helpers.getlatestNodeReleaseVersion()
       const pointPath = helpers.getPointPath()
       const filename = this.getNodeFileName(version)
 
@@ -234,9 +234,9 @@ export default class Node {
 
   async checkNodeVersion() {
     const pointPath = helpers.getPointPath()
-    const installedVersion = helpers.getInstalledVersion()
+    const installedVersion = helpers.getInstalledNodeVersion()
 
-    const latestReleaseVersion = await helpers.getlatestReleaseVersion()
+    const latestReleaseVersion = await helpers.getlatestNodeReleaseVersion()
 
     logger.info('installed', installedVersion.installedReleaseVersion)
     logger.info('last', latestReleaseVersion)
@@ -257,7 +257,7 @@ export default class Node {
     }
   }
 
-  async getIdentity(){
+  async getIdentity() {
     logger.info('Get Identity')
     const addressRes = await axios.get(
       'http://localhost:2468/v1/api/wallet/address'
@@ -265,7 +265,9 @@ export default class Node {
     const address = addressRes.data.data.address
     logger.info('Get Identity adress', address)
     try {
-      console.log(`http://localhost:2468/v1/api/identity/ownerToIdentity/${address}`)
+      console.log(
+        `http://localhost:2468/v1/api/identity/ownerToIdentity/${address}`
+      )
       const identity = await axios.get(
         `http://localhost:2468/v1/api/identity/ownerToIdentity/${address}`
       )
@@ -273,11 +275,5 @@ export default class Node {
     } catch (e) {
       logger.error(e)
     }
-  }
-
-  async getDashboardVersion(){
-    var pjson = require('../../package.json');
-    console.log('json vetrsion',pjson.version);
-    this.window.webContents.send('node:getDashboardVersion', pjson.version)
   }
 }


### PR DESCRIPTION
This PR adds a download link alert whenever we have a new release of the dashboard for the user to download.

To mock the functionality, change the `version` in `package.json` to lesser than the current one, `yarn start` and the Alert should show up in the top-right corner of the dashboard.

To actually test it out, create a binary while still in the `feature/dashboard-update-link` branch (it's on version `0.2.12`), create a new release on GitHub (which would be `0.2.13`), then again run the created binary. Ideally, it should show the update alert. If not, then report IMMEDIATELY.