### PR TITLE
PD-132 Remove extra space from NODE_ENV in Windows.

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -164,7 +164,7 @@ export default class Node {
       file = path.join(pointPath, 'bin', 'macos', 'point')
 
     let cmd = `NODE_ENV=production ${file}`
-    if (global.platform.win32) cmd = `set NODE_ENV=production && ${file}`
+    if (global.platform.win32) cmd = `set NODE_ENV=production&&${file}`
 
     exec(cmd, (error: { message: any }, _stdout: any, stderr: any) => {
       logger.info('Launched Node')


### PR DESCRIPTION
Using this simple script as an example (_ex.js_):
```javascript
const env = process.env.NODE_ENV || ""
console.log(env.length)
```

Before this PR (`set NODE_ENV=production && node ex.js`):
`11`

After this PR (`set NODE_ENV=production&&node ex.js`):
`10`

Please refer to the [ticket description](https://point-labs.atlassian.net/browse/PD-132) for further details.