### PR TITLE
Add a fix for the username containing spaces

### DIFF
--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -190,17 +190,16 @@ export default class {
       const extensionPath = helpers.getPointPath()
       const downloadManifest = this.getURL('manifest.json', version)
       const downloadPathManifest = path.join(extensionPath, 'manifest.json')
-      const manifest = fs.createWriteStream(downloadPathManifest);
+      const manifest = fs.createWriteStream(downloadPathManifest)
       https.https.get(downloadManifest, function (response) {
-        response.pipe(manifest);
-      });
-      manifest.on("finish", async () => {
-        manifest.close();
-        console.log("Download Manifest Completed");
+        response.pipe(manifest)
+      })
+      manifest.on('finish', async () => {
+        manifest.close()
+        console.log('Download Manifest Completed')
         resolve(true)
-      });
+      })
     })
-
 
   downloadInstallPointSDK = async () =>
     // eslint-disable-next-line no-async-promise-executor
@@ -258,7 +257,6 @@ export default class {
         )
         this.window.webContents.send('pointSDK:finishDownload', true)
 
-
         // stringify JSON Object
         fs.writeFile(
           path.join(pointPath, 'infoSDK.json'),
@@ -266,9 +264,7 @@ export default class {
           'utf8',
           function (err: any) {
             if (err) {
-              logger.info(
-                'An error occured while writing JSON Object to File.'
-              )
+              logger.info('An error occured while writing JSON Object to File.')
               return logger.info(err)
             }
 
@@ -281,7 +277,6 @@ export default class {
             'Installed Firefox successfully'
           )
         )
-
       })
     })
 
@@ -319,7 +314,7 @@ export default class {
       '.point/keystore/liveprofile'
     )
 
-    const browserCmd = `${cmd} --first-startup --profile ${profilePath} --url https://point`
+    const browserCmd = `"${cmd}" --first-startup --profile "${profilePath}" --url https://point`
 
     this.window.webContents.send('firefox:active', true)
     try {
@@ -331,7 +326,7 @@ export default class {
   }
 
   getKillCmd(pid: number) {
-    return global.platform.win32 ? `taskkill /F /PID ${pid}` : `kill ${pid}`
+    return global.platform.win32 ? `taskkill /F /PID "${pid}"` : `kill "${pid}"`
   }
 
   async close() {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -159,12 +159,12 @@ export default class Node {
 
     let file = path.join(pointPath, 'bin', 'linux', 'point')
     if (global.platform.win32)
-      file = `"${path.join(pointPath, 'bin', 'win', 'point')}"`
+      file = path.join(pointPath, 'bin', 'win', 'point')
     if (global.platform.darwin)
       file = path.join(pointPath, 'bin', 'macos', 'point')
 
-    let cmd = `NODE_ENV=production ${file}`
-    if (global.platform.win32) cmd = `set NODE_ENV=production&&${file}`
+    let cmd = `NODE_ENV=production "${file}"`
+    if (global.platform.win32) cmd = `set NODE_ENV=production&&"${file}"`
 
     exec(cmd, (error: { message: any }, _stdout: any, stderr: any) => {
       logger.info('Launched Node')
@@ -217,8 +217,8 @@ export default class Node {
     if (process.length > 0) {
       logger.info(`Found running process ${process}`)
       this.killCmd = process.map((obj: { pid: any }) => {
-        let command = `kill ${obj.pid}`
-        if (global.platform.win32) command = `taskkill /F /PID ${obj.pid}`
+        let command = `kill "${obj.pid}"`
+        if (global.platform.win32) command = `taskkill /F /PID "${obj.pid}"`
         return command
       })
       logger.info(`cmd: ${this.killCmd}`)


### PR DESCRIPTION
Fixes the issues we had with installation when username contains space.

References: 
[https://www.howtogeek.com/694949/how-to-escape-spaces-in-file-paths-on-the-windows-command-line/](https://www.howtogeek.com/694949/how-to-escape-spaces-in-file-paths-on-the-windows-command-line/)
[https://medium.com/@leedowthwaite/dealing-with-spaces-in-paths-f26856aef06f](https://medium.com/@leedowthwaite/dealing-with-spaces-in-paths-f26856aef06f)