### PR TITLE
Avoid duplicates in secret phrase validation words

### DIFF
--- a/src/welcome/helpers/index.ts
+++ b/src/welcome/helpers/index.ts
@@ -1,2 +1,1 @@
-export * from './phrase'
 export * from './random'

--- a/src/welcome/helpers/random.test.ts
+++ b/src/welcome/helpers/random.test.ts
@@ -12,10 +12,24 @@ describe('pickMultipleRandomly', () => {
   })
 
   it('picks words contained in the input array', () => {
-    output.forEach(n => expect(input).toContain(n))
+    output.forEach(i => expect(input).toContain(i.word))
+  })
+
+  it('returns the correct index for the picked words', () => {
+    output.forEach(({word, idx}) => expect(word).toBe(input[idx]))
   })
 
   it('does not pick any duplicates', () => {
-    expect(Array.from(new Set(output))).toHaveLength(4)
+    // Run it 100 times.
+    for (let i = 0; i < 100; i++) {
+      const picks = pickMultipleRandomly(input, 3)
+
+      const seen: Record<string, number> = {}
+      picks.forEach(i => {
+        seen[i.word] = (seen[i.word] || 0) + 1
+      })
+
+      Object.keys(seen).forEach(k => expect(seen[k]).toBe(1))
+    }
   })
 })

--- a/src/welcome/helpers/random.ts
+++ b/src/welcome/helpers/random.ts
@@ -14,17 +14,19 @@ function removeFromArray<T>(arr: T[], target: T): T[] {
   return arr.filter(i => i !== target)
 }
 
+export type Word = { word: string; idx: number }
+
 /**
  * Randomly picks a given quantity of elements from an array,
  * without duplicating picks.
  */
-export function pickMultipleRandomly<T>(arr: T[], quantity: number): T[] {
+export function pickMultipleRandomly(arr: string[], quantity: number): Word[] {
   let availableOptions = [...arr]
-  const picks = []
+  const picks: Word[]  = []
 
   for (let i = 0; i < quantity; i++) {
     const pick = pickRandomly(availableOptions)
-    picks.push(pick)
+    picks.push({ word: pick, idx: arr.indexOf(pick) })
     availableOptions = removeFromArray(availableOptions, pick)
   }
 

--- a/src/welcome/service.test.ts
+++ b/src/welcome/service.test.ts
@@ -1,0 +1,36 @@
+/** @jest-environment node */
+import { BrowserWindow } from 'electron'
+import WelcomeService from './service'
+import { WelcomeChannelsEnum } from '../@types/ipc_channels'
+
+type Args = [WelcomeChannelsEnum, any]
+
+const mockSend = jest.fn(() => {})
+
+const mockWindow = {
+  webContents: {
+    send: mockSend,
+  },
+}
+
+describe('WelcomeService', () => {
+  const welcomeService = new WelcomeService(mockWindow as unknown as BrowserWindow)
+
+  it('should generate a secret phrase and validate it with a subset of words', async () => {
+    expect.assertions(6)
+
+    await welcomeService.generate()
+    welcomeService.getGeneratedMnemonic()
+    const picks = welcomeService.pickRandomWords()
+    const words = picks.map(i => i.word)
+    welcomeService.verifyWords(words)
+
+    const calls = mockSend.mock.calls as unknown as Args[]
+    expect(calls[0][0]).toBe(WelcomeChannelsEnum.get_dictionary)
+    expect(calls[1][0]).toBe(WelcomeChannelsEnum.generate_mnemonic)
+    expect(calls[2][0]).toBe(WelcomeChannelsEnum.get_mnemonic)
+    expect(calls[3][0]).toBe(WelcomeChannelsEnum.pick_words)
+    expect(calls[4][0]).toBe(WelcomeChannelsEnum.validate_words)
+    expect(calls[4][1]).toBe(true)
+  })
+})

--- a/src/welcome/service.ts
+++ b/src/welcome/service.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import Mnemonic from 'bitcore-mnemonic'
 import Logger from '../../shared/logger'
 import helpers from '../../shared/helpers'
+import { pickMultipleRandomly, Word } from './helpers'
 // Types
 import { WelcomeChannelsEnum } from '../@types/ipc_channels'
 
@@ -12,7 +13,7 @@ class WelcomeService {
   private window: BrowserWindow
   private logger: Logger
   private mnemonic: string = ''
-  private picks: { word: string; idx: number }[] = []
+  private picks: Word[] = []
 
   constructor(window: BrowserWindow) {
     this.window = window
@@ -109,16 +110,9 @@ class WelcomeService {
   /**
    * Pick words randomly and send for verification
    */
-  pickRandomWords(): { word: string; idx: number }[] {
+  pickRandomWords(): Word[] {
     const availableOptions = this.mnemonic.split(' ')
-
-    this.picks = []
-    for (let i = 0; i < 3; i++) {
-      const idx = Math.floor(Math.random() * availableOptions.length)
-      const word = availableOptions[idx]
-      this.picks.push({ word, idx })
-    }
-
+    this.picks = pickMultipleRandomly(availableOptions, 3)
     this.window.webContents.send(WelcomeChannelsEnum.pick_words, this.picks)
     return this.picks
   }


### PR DESCRIPTION
Use the `pickMultipleRandomly` function to get 3 words out of the 12-word secret phrase for validation without duplicates.

I have created some tests for `src/welcome/service.ts`. In the future, we may want to go with something like Playwright to do some end-to-end testing, clicking on buttons, typing into inputs, and ensuring the UI responds as expected. But for now, I think that this simple approach of mocking the BrowserWindow is good enough to at least be able to test that messages are sent with the expected payload.

In addition to the unit tests, I've run the Dashboard locally a few times and created new accounts each time, mostly to make sure that nothing breaks, but I've also checked that no duplicated words were chosen (although chances are slim with so little manual tests).