### PR TITLE
Refactor the way components are updated and started

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ dist
 webpack/*.js
 .webpack
 out
+liveprofile
+resources

--- a/build_installer_win.js
+++ b/build_installer_win.js
@@ -44,11 +44,11 @@ const msiCreator = new MSICreator({
 })
 
 msiCreator.create().then(function(binaries) {
-    //binaries.supportBinaries.forEach((filepath) => {
+    // binaries.supportBinaries.forEach((filepath) => {
     //    if (filepath.match(/point.exe$/)) {
     //        // sign the binary
     //    }
-    //})
+    // })
     fs.copyFileSync(path.join(APP_DIR, 'point.exe'), path.join(OUT_DIR, 'point.exe'))
     msiCreator.compile().then(()=>{
         console.log('Compiled succesfully')

--- a/package-lock.json
+++ b/package-lock.json
@@ -7677,19 +7677,19 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "node_modules/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "3.1.1",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.9.7",
-        "raw-body": "2.4.3",
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
         "type-is": "~1.6.18"
       },
       "engines": {
@@ -8008,9 +8008,9 @@
       }
     },
     "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8801,9 +8801,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12621,16 +12621,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
       "dependencies": {
-        "accepts": "~1.3.8",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.2",
+        "body-parser": "1.19.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.2",
+        "cookie": "0.4.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -12645,7 +12645,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.7",
+        "qs": "6.9.6",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.17.2",
@@ -23908,9 +23908,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
       "engines": {
         "node": ">=0.6"
       },
@@ -23999,11 +23999,11 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
-      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "3.1.1",
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
@@ -27952,6 +27952,158 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/body-parser": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/express": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -27966,6 +28118,54 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/webpack-dev-server/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/webpack-dev-server/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {
       "version": "4.0.0",
@@ -27984,6 +28184,60 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/webpack-dev-server/node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dev": true,
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
@@ -34315,19 +34569,19 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
       "requires": {
-        "bytes": "3.1.2",
+        "bytes": "3.1.1",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.9.7",
-        "raw-body": "2.4.3",
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
         "type-is": "~1.6.18"
       },
       "dependencies": {
@@ -34574,9 +34828,9 @@
       }
     },
     "bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
     },
     "cacache": {
       "version": "15.3.0",
@@ -35203,9 +35457,9 @@
       }
     },
     "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -38062,16 +38316,16 @@
       }
     },
     "express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
       "requires": {
-        "accepts": "~1.3.8",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.2",
+        "body-parser": "1.19.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.2",
+        "cookie": "0.4.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -38086,7 +38340,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.7",
+        "qs": "6.9.6",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.17.2",
@@ -46587,9 +46841,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "query-string": {
       "version": "5.1.1",
@@ -46648,11 +46902,11 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
-      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
       "requires": {
-        "bytes": "3.1.2",
+        "bytes": "3.1.1",
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
@@ -49765,6 +50019,132 @@
             "fast-deep-equal": "^3.1.3"
           }
         },
+        "body-parser": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+          "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "on-finished": "2.4.1",
+            "qs": "6.10.3",
+            "raw-body": "2.5.1",
+            "type-is": "~1.6.18",
+            "unpipe": "1.0.0"
+          }
+        },
+        "bytes": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "destroy": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+          "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+          "dev": true
+        },
+        "express": {
+          "version": "4.18.1",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+          "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.8",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.20.0",
+            "content-disposition": "0.5.4",
+            "content-type": "~1.0.4",
+            "cookie": "0.5.0",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.2.0",
+            "fresh": "0.5.2",
+            "http-errors": "2.0.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "2.4.1",
+            "parseurl": "~1.3.3",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.7",
+            "qs": "6.10.3",
+            "range-parser": "~1.2.1",
+            "safe-buffer": "5.2.1",
+            "send": "0.18.0",
+            "serve-static": "1.15.0",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "type-is": "~1.6.18",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+          "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "2.4.1",
+            "parseurl": "~1.3.3",
+            "statuses": "2.0.1",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "dev": true,
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
         "ipaddr.js": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -49777,6 +50157,42 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        },
+        "on-finished": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+          "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "qs": {
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "raw-body": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
         "schema-utils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -49788,6 +50204,53 @@
             "ajv-formats": "^2.1.1",
             "ajv-keywords": "^5.0.0"
           }
+        },
+        "send": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+          "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "2.0.0",
+            "mime": "1.6.0",
+            "ms": "2.1.3",
+            "on-finished": "2.4.1",
+            "range-parser": "~1.2.1",
+            "statuses": "2.0.1"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+              "dev": true
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+          "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
+            "send": "0.18.0"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
         },
         "ws": {
           "version": "8.6.0",

--- a/src/@types/context.d.ts
+++ b/src/@types/context.d.ts
@@ -1,0 +1,30 @@
+import {GenericProgressLog, IsUpdatingState, UpdateLog} from "./generic";
+
+export type MainStatus = {
+  isBrowserRunning: boolean
+  isNodeRunning: boolean
+  identifier: string
+  browserVersion: string
+  nodeVersion: string
+  launchAttempts: number
+  loader: {
+    isLoading: boolean
+    message: string
+  }
+}
+
+export type UpdateStatus = {
+  isUpdating: IsUpdatingState
+  updateDialogOpen: boolean
+  nodeLog: string
+  nodeDownloadLogs: GenericProgressLog
+  nodeUpdateLogs: UpdateLog
+  nodeUnpackLogs: GenericProgressLog
+  firefoxLog: string
+  firefoxDownloadLogs: GenericProgressLog
+  firefoxUpdateLogs: UpdateLog
+  firefoxUnpackLogs: GenericProgressLog
+  sdkLog: string
+  sdkDownloadLogs: GenericProgressLog
+  sdkUpdateLogs: UpdateLog
+}

--- a/src/dashboard/bridge.ts
+++ b/src/dashboard/bridge.ts
@@ -30,20 +30,43 @@ export const api = {
   getIdentityInfo: () => ipcRenderer.send(NodeChannelsEnum.get_identity),
   pingNode: () => ipcRenderer.send(NodeChannelsEnum.running_status),
   launchNodeAndPing: () => ipcRenderer.send(NodeChannelsEnum.launch),
-  getNodeVersion: () => ipcRenderer.send(NodeChannelsEnum.get_version),
+  getNodeVersion: () => new Promise<string>((resolve) => {
+    ipcRenderer.once(NodeChannelsEnum.get_version, (_, v: string) => {
+      resolve(v)
+    })
+    ipcRenderer.send(NodeChannelsEnum.get_version)
+  }),
   // Uninstaller
   launchUninstaller: () => ipcRenderer.send(UninstallerChannelsEnum.launch),
   // Firefox
-  getFirefoxVersion: () => ipcRenderer.send(FirefoxChannelsEnum.get_version),
+  getFirefoxVersion: () => new Promise<string>((resolve) => {
+    ipcRenderer.once(FirefoxChannelsEnum.get_version, (_, v: string) => {
+      resolve(v)
+    })
+    ipcRenderer.send(FirefoxChannelsEnum.get_version)
+  }),
   launchBrowser: () => ipcRenderer.send(FirefoxChannelsEnum.launch),
   // Generic
   copyToClipboard: (message: string) =>
     ipcRenderer.send(GenericChannelsEnum.copy_to_clipboard, message),
   openExternalLink: (link: string) =>
     ipcRenderer.send(GenericChannelsEnum.open_external_link, link),
-  getIndentifier: () => ipcRenderer.send(GenericChannelsEnum.get_identifier),
-  checkForUpdates: () =>
-    ipcRenderer.send(GenericChannelsEnum.check_for_updates),
+  getIndentifier: () => new Promise<string>((resolve) => {
+    ipcRenderer.once(GenericChannelsEnum.get_identifier, (_, id: string) => {
+      resolve(id)
+    })
+    ipcRenderer.send(GenericChannelsEnum.get_identifier)
+  }),
+  checkForUpdates: () => new Promise<void>((resolve, reject) => {
+    ipcRenderer.once(GenericChannelsEnum.check_for_updates, (_, log: string) => {
+      if (JSON.parse(log).success) {
+        resolve()
+      } else {
+        reject(new Error('Updates check failed'))
+      }
+    })
+    ipcRenderer.send(GenericChannelsEnum.check_for_updates)
+  }),
   minimizeWindow: () => ipcRenderer.send(GenericChannelsEnum.minimize_window),
   closeWindow: () => ipcRenderer.send(GenericChannelsEnum.close_window),
 

--- a/src/dashboard/context/MainStatusContext.ts
+++ b/src/dashboard/context/MainStatusContext.ts
@@ -1,0 +1,118 @@
+import {createContext, useEffect, useState} from "react";
+import {
+  DashboardChannelsEnum,
+  FirefoxChannelsEnum,
+  NodeChannelsEnum,
+  UninstallerChannelsEnum
+} from "../../@types/ipc_channels";
+import {LaunchProcessLog} from "../../@types/generic";
+import {MainStatus} from "../../@types/context";
+
+export const useMainStatus = () => {
+  const [identifier, setIdentifier] = useState<string>('')
+  const [browserVersion, setBrowserVersion] = useState<string>('')
+  const [nodeVersion, setNodeVersion] = useState<string>('')
+  const [launchAttempts, setLaunchAttempts] = useState<number>(0)
+  const [loader, setIsLaunching] = useState<{
+    isLoading: boolean
+    message: string
+  }>({ isLoading: true, message: 'Starting Point Network' })
+  const [isBrowserRunning, setIsBrowserRunning] = useState<boolean>(false)
+  const [isNodeRunning, setIsNodeRunning] = useState<boolean>(false)
+
+  // Register these events once to prevent leaks
+  const setListeners = () => {
+    window.Dashboard.on(NodeChannelsEnum.running_status, (_: string) => {
+      const parsed: LaunchProcessLog = JSON.parse(_)
+      setIsNodeRunning(parsed.isRunning)
+
+      if (!parsed.isRunning) {
+        setTimeout(window.Dashboard.launchNodeAndPing, 2000)
+        setLaunchAttempts(prev => {
+          if (prev >= 5) {
+            setIsLaunching(prev => ({
+              ...prev,
+              message: `Starting Point Network (please wait)`,
+            }))
+          }
+          return prev + 1
+        })
+      } else {
+        setLaunchAttempts(0)
+      }
+    })
+
+    window.Dashboard.on(FirefoxChannelsEnum.running_status, (_: string) => {
+      const parsed: LaunchProcessLog = JSON.parse(_)
+      setIsBrowserRunning(parsed.isRunning)
+    })
+
+    window.Dashboard.on(UninstallerChannelsEnum.running_status, (_: string) => {
+      const parsed: LaunchProcessLog = JSON.parse(_)
+      setIsLaunching({ isLoading: parsed.isRunning, message: parsed.log })
+    })
+
+    window.Dashboard.on(DashboardChannelsEnum.closing, () => {
+      setIsLaunching({
+        isLoading: true,
+        message: 'Closing Point',
+      })
+    })
+
+    window.Dashboard.on(DashboardChannelsEnum.log_out, () => {
+      setIsLaunching({
+        isLoading: true,
+        message: 'Logging Out',
+      })
+    })
+  }
+
+  const getInfo = async () => {
+    const [id, pointNodeVersion, firefoxVersion] = await Promise.all([
+      window.Dashboard.getIndentifier(),
+      window.Dashboard.getNodeVersion(),
+      window.Dashboard.getFirefoxVersion()
+    ])
+    setIdentifier(id)
+    setNodeVersion(pointNodeVersion)
+    setBrowserVersion(firefoxVersion)
+  }
+
+  // 1. Set listeners, get info and start node
+  const init = async () => {
+    setListeners()
+    getInfo()
+    await window.Dashboard.checkForUpdates()
+    window.Dashboard.launchNodeAndPing()
+  }
+  useEffect(() => {
+    init()
+  }, [])
+
+  // 2. Once node is running, we launch the browser
+  useEffect(() => {
+    if (isNodeRunning) window.Dashboard.launchBrowser()
+  }, [isNodeRunning])
+
+  // 3. Once browser is running, we finish the launch procedure
+  useEffect(() => {
+    if (isBrowserRunning) {
+      setIsLaunching({
+        isLoading: false,
+        message: 'Launched',
+      })
+    }
+  }, [isBrowserRunning])
+
+  return {
+    isBrowserRunning,
+    isNodeRunning,
+    identifier,
+    browserVersion,
+    nodeVersion,
+    launchAttempts,
+    loader
+  }
+}
+
+export const MainStatusContext = createContext<MainStatus>({} as unknown as MainStatus)

--- a/src/dashboard/context/UpdateStatusContext.ts
+++ b/src/dashboard/context/UpdateStatusContext.ts
@@ -1,0 +1,181 @@
+import {createContext, useEffect, useState} from "react";
+import {GenericProgressLog, IsUpdatingState, UpdateLog} from "../../@types/generic";
+import {
+  FirefoxChannelsEnum,
+  NodeChannelsEnum,
+  PointSDKChannelsEnum
+} from "../../@types/ipc_channels";
+import {UpdateStatus} from "../../@types/context";
+
+export const useUpdateStatus = () => {
+  const [isUpdating, setIsUpdating] = useState<IsUpdatingState>({
+    firefox: false,
+    node: false,
+    pointsdk: false,
+    firefoxError: false,
+    nodeError: false,
+    pointsdkError: false,
+  })
+  const updateDialogOpen = Object.keys(isUpdating)
+    .reduce((acc, cur) => acc || isUpdating[cur as 'firefox'], false)
+
+  const [nodeLog, setNodeLog] = useState('')
+  const [nodeDownloadLogs, setNodeDownloadLogs] = useState<GenericProgressLog>({
+    started: false,
+    progress: 0,
+    log: '',
+    error: false,
+    done: false,
+  })
+  const [nodeUnpackLogs, setNodeUnpackLogs] = useState<GenericProgressLog>({
+    started: false,
+    progress: 0,
+    log: '',
+    error: false,
+    done: false,
+  })
+  const [nodeUpdateLogs, setNodeUpdateLogs] = useState<UpdateLog>({
+    isAvailable: false,
+    isChecking: true,
+    log: '',
+    error: false
+  })
+
+  const [firefoxLog, setFirefoxLog] = useState('')
+  const [firefoxDownloadLogs, setFirefoxDownloadLogs] = useState<GenericProgressLog>({
+    started: false,
+    progress: 0,
+    log: '',
+    error: false,
+    done: false,
+  })
+  const [firefoxUnpackLogs, setFirefoxUnpackLogs] = useState<GenericProgressLog>({
+    started: false,
+    progress: 0,
+    log: '',
+    error: false,
+    done: false,
+  })
+  const [firefoxUpdateLogs, setFirefoxUpdateLogs] = useState<UpdateLog>({
+    isAvailable: false,
+    isChecking: true,
+    log: '',
+    error: false
+  })
+
+  const [sdkLog, setSdkLog] = useState('')
+  const [sdkDownloadLogs, setSdkDownloadLogs] = useState<GenericProgressLog>({
+    started: false,
+    progress: 0,
+    log: '',
+    error: false,
+    done: false,
+  })
+  const [sdkUpdateLogs, setSdkUpdateLogs] = useState<UpdateLog>({
+    isAvailable: false,
+    isChecking: true,
+    log: '',
+    error: false
+  })
+
+  useEffect(() => {
+    window.Dashboard.on(NodeChannelsEnum.check_for_updates, (logs: string) => {
+      const parsed = JSON.parse(logs) as UpdateLog
+      setNodeUpdateLogs(parsed)
+      setNodeLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        node: parsed.isAvailable,
+        nodeError: parsed.error
+      }))
+    })
+    window.Dashboard.on(FirefoxChannelsEnum.check_for_updates, (logs: string) => {
+      const parsed = JSON.parse(logs) as UpdateLog
+      setFirefoxUpdateLogs(parsed)
+      setFirefoxLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        firefox: parsed.isAvailable,
+        firefoxError: parsed.error
+      }))
+    })
+    window.Dashboard.on(PointSDKChannelsEnum.check_for_updates, (logs: string) => {
+      const parsed = JSON.parse(logs) as UpdateLog
+      setSdkUpdateLogs(parsed)
+      setSdkLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        pointsdk: parsed.isAvailable,
+        pointsdkError: parsed.error
+      }))
+    })
+
+    window.Dashboard.on(NodeChannelsEnum.download, (logs: string) => {
+      const parsed = JSON.parse(logs) as GenericProgressLog
+      setNodeDownloadLogs(parsed)
+      setNodeLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        nodeError: parsed.error,
+      }))
+    })
+    window.Dashboard.on(FirefoxChannelsEnum.download, (logs: string) => {
+      const parsed = JSON.parse(logs) as GenericProgressLog
+      setFirefoxDownloadLogs(parsed)
+      setFirefoxLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        firefoxError: parsed.error,
+      }))
+    })
+    window.Dashboard.on(PointSDKChannelsEnum.download, (logs: string) => {
+      const parsed = JSON.parse(logs) as GenericProgressLog
+      setSdkDownloadLogs(parsed)
+      setSdkLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        pointsdk: !parsed.done,
+        pointsdkError: parsed.error,
+      }))
+    })
+
+    window.Dashboard.on(NodeChannelsEnum.unpack, (logs: string) => {
+      const parsed = JSON.parse(logs) as GenericProgressLog
+      setNodeUnpackLogs(parsed)
+      setNodeLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        node: !parsed.done,
+        nodeError: parsed.error,
+      }))
+    })
+    window.Dashboard.on(FirefoxChannelsEnum.unpack, (logs: string) => {
+      const parsed = JSON.parse(logs) as GenericProgressLog
+      setFirefoxUnpackLogs(parsed)
+      setFirefoxLog(parsed.log)
+      setIsUpdating(prev => ({
+        ...prev,
+        firefox: !parsed.done,
+        firefoxError: parsed.error,
+      }))
+    })
+  }, [])
+
+  return {
+    isUpdating,
+    updateDialogOpen,
+    nodeLog,
+    nodeDownloadLogs,
+    nodeUpdateLogs,
+    nodeUnpackLogs,
+    firefoxLog,
+    firefoxDownloadLogs,
+    firefoxUpdateLogs,
+    firefoxUnpackLogs,
+    sdkLog,
+    sdkDownloadLogs,
+    sdkUpdateLogs
+  }
+}
+
+export const UpdateStatusContext = createContext<UpdateStatus>({} as unknown as UpdateStatus)

--- a/src/dashboard/ui/App.tsx
+++ b/src/dashboard/ui/App.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react'
+import {FunctionComponent, useContext} from 'react'
 // MUI
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
+// Context
+import {useMainStatus, MainStatusContext} from '../context/MainStatusContext'
 // Components
-import CheckForUpdatesDailog from './components/CheckForUpdatesDailog'
+import CheckForUpdatesDialog from './components/CheckForUpdatesDialog'
 import DashboardTitle from './components/DashboardTitle'
 import DefaultLoader from './components/DefaultLoader'
 import DisplayIdentifier from '../../../shared/react-components/DisplayIdentifier'
@@ -13,126 +15,22 @@ import UIThemeProvider from '../../../shared/react-components/UIThemeProvider'
 import WalletInfo from './components/WalletInfo'
 import DashboardUpdateAlert from './components/DashboardUpdateAlert'
 import TimeoutAlert from './components/TimeoutAlert'
-// Types
-import {
-  DashboardChannelsEnum,
-  FirefoxChannelsEnum,
-  GenericChannelsEnum,
-  NodeChannelsEnum,
-  UninstallerChannelsEnum,
-} from '../../@types/ipc_channels'
-import { LaunchProcessLog } from '../../@types/generic'
 // Icons
 import { ReactComponent as FirefoxLogo } from '../../../assets/firefox-logo.svg'
 import { ReactComponent as PointLogo } from '../../../assets/point-logo.svg'
+import {UpdateStatusContext, useUpdateStatus} from "../context/UpdateStatusContext";
 
 const App = () => {
-  const [identifier, setIdentifier] = useState<string>('')
-  const [browserVersion, setBrowserVersion] = useState<string>('')
-  const [nodeVersion, setNodeVersion] = useState<string>('')
-  // Update related state variables
-  const [updateDialogOpen, setUpdateDialogOpen] = useState<boolean>(true)
-  // Running state variables
-  const [launchAttempts, setLaunchAttempts] = useState<number>(0)
-  const [loader, setIsLaunching] = useState<{
-    isLoading: boolean
-    message: string
-  }>({ isLoading: true, message: 'Starting Point Network' })
-  const [isBrowserRunning, setIsBrowserRunning] = useState<boolean>(false)
-  const [isNodeRunning, setIsNodeRunning] = useState<boolean>(false)
-
-  // 1. The very first thing we do is to check for updates
-  useEffect(() => {
-    window.Dashboard.checkForUpdates()
-  }, [])
-
-  // 2. If everything is up to date, we wait for update dailog to close, then we launch the node first and ping it
-  useEffect(() => {
-    if (!updateDialogOpen) {
-      window.Dashboard.launchNodeAndPing()
-      setInterval(window.Dashboard.pingNode, 10000)
-    }
-  }, [updateDialogOpen])
-
-  // 3. Once node is running, we launch the browser
-  useEffect(() => {
-    if (isNodeRunning) window.Dashboard.launchBrowser()
-  }, [isNodeRunning])
-
-  // 4. Once browser is running, we finish the launch procedure
-  useEffect(() => {
-    if (isBrowserRunning) {
-      setIsLaunching({
-        isLoading: false,
-        message: 'Launched',
-      })
-    }
-  }, [isBrowserRunning])
-
-  // Register these events once to prevent leaks
-  useEffect(() => {
-    window.Dashboard.getIndentifier()
-    window.Dashboard.getFirefoxVersion()
-    window.Dashboard.getNodeVersion()
-
-    window.Dashboard.on(NodeChannelsEnum.running_status, (_: string) => {
-      const parsed: LaunchProcessLog = JSON.parse(_)
-      setIsNodeRunning(parsed.isRunning)
-
-      if (!parsed.isRunning) {
-        console.log('Entered !parsed.isRunning')
-        setTimeout(window.Dashboard.launchNodeAndPing, 2000)
-        setLaunchAttempts(prev => {
-          if (prev >= 5)
-            setIsLaunching(prev => ({
-              ...prev,
-              message: `Starting Point Network (please wait)`,
-            }))
-          return prev + 1
-        })
-      } else {
-        setLaunchAttempts(0)
-      }
-    })
-
-    window.Dashboard.on(FirefoxChannelsEnum.running_status, (_: string) => {
-      const parsed: LaunchProcessLog = JSON.parse(_)
-      setIsBrowserRunning(parsed.isRunning)
-    })
-
-    window.Dashboard.on(UninstallerChannelsEnum.running_status, (_: string) => {
-      const parsed: LaunchProcessLog = JSON.parse(_)
-      setIsLaunching({ isLoading: parsed.isRunning, message: parsed.log })
-    })
-
-    window.Dashboard.on(DashboardChannelsEnum.closing, () => {
-      setIsLaunching({
-        isLoading: true,
-        message: 'Closing Point',
-      })
-    })
-
-    window.Dashboard.on(DashboardChannelsEnum.log_out, () => {
-      setIsLaunching({
-        isLoading: true,
-        message: 'Logging Out',
-      })
-    })
-
-    window.Dashboard.on(
-      GenericChannelsEnum.get_identifier,
-      (identifier: string) => {
-        setIdentifier(identifier)
-      }
-    )
-
-    window.Dashboard.on(FirefoxChannelsEnum.get_version, (v: string) => {
-      setBrowserVersion(v)
-    })
-    window.Dashboard.on(NodeChannelsEnum.get_version, (v: string) => {
-      setNodeVersion(v)
-    })
-  }, [])
+  const {
+    isBrowserRunning,
+    isNodeRunning,
+    browserVersion,
+    nodeVersion,
+    identifier,
+    launchAttempts,
+    loader
+  } = useContext(MainStatusContext)
+  const {updateDialogOpen} = useContext(UpdateStatusContext)
 
   return (
     <UIThemeProvider>
@@ -141,10 +39,7 @@ const App = () => {
       <DashboardUpdateAlert />
       <TimeoutAlert identifier={identifier} launchAttempts={launchAttempts} />
 
-      <CheckForUpdatesDailog
-        dialogOpen={updateDialogOpen}
-        setDialogOpen={setUpdateDialogOpen}
-      />
+      <CheckForUpdatesDialog />
 
       <DefaultLoader
         isOpen={loader.isLoading && !updateDialogOpen}
@@ -183,4 +78,15 @@ const App = () => {
   )
 }
 
-export default App
+const AppWithContext: FunctionComponent = () => {
+  const mainStatus = useMainStatus()
+  const updateStatus = useUpdateStatus()
+
+  return <MainStatusContext.Provider value={mainStatus}>
+    <UpdateStatusContext.Provider value={updateStatus}>
+      <App/>
+    </UpdateStatusContext.Provider>
+  </MainStatusContext.Provider>
+}
+
+export default AppWithContext

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -283,8 +283,7 @@ class Firefox {
             error: false,
           } as UpdateLog),
         })
-        await this.stop()
-        this.downloadAndInstall()
+        return true
       } else {
         this.logger.info('Already up to date')
         this.logger.sendToChannel({
@@ -296,6 +295,7 @@ class Firefox {
             error: false,
           } as UpdateLog),
         })
+        return false
       }
     } catch (error) {
       this.logger.sendToChannel({

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -166,13 +166,15 @@ class Node {
 
   /**
    * Checks
-   * 1. If Point Engine exists or not, if it doesn't then downloads it
+   * 1. If Point Engine exists or not, if not then returns early
    * 2. Checks if there are any running instances of Point Engine, if yes then returns early
    * 3. Launches Point Engine
    */
   async launch() {
     try {
-      if (!fs.existsSync(this._getBinFile())) return
+      if (!fs.existsSync(this._getBinFile())) {
+        this.logger.error('Trying to launch point node, but bin file does not exist')
+      }
       if ((await this._getRunningProcess()).length) {
         this.logger.info(
           'Point node is currently running. Skipping starting it'
@@ -316,8 +318,7 @@ class Node {
             error: false,
           } as UpdateLog),
         })
-        await this.stop()
-        await this.downloadAndInstall()
+        return true
       } else {
         this.logger.info('Already up to date')
         this.logger.sendToChannel({
@@ -329,6 +330,7 @@ class Node {
             error: false,
           } as UpdateLog),
         })
+        return false
       }
     } catch (error) {
       this.logger.sendToChannel({

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -174,6 +174,7 @@ class Node {
     try {
       if (!fs.existsSync(this._getBinFile())) {
         this.logger.error('Trying to launch point node, but bin file does not exist')
+        return
       }
       if ((await this._getRunningProcess()).length) {
         this.logger.info(

--- a/src/pointsdk/index.ts
+++ b/src/pointsdk/index.ts
@@ -141,7 +141,7 @@ class PointSDK {
             error: false,
           } as UpdateLog),
         })
-        this.downloadAndInstall()
+        return true
       } else {
         this.logger.info('Already up to date')
         this.logger.sendToChannel({
@@ -153,6 +153,7 @@ class PointSDK {
             error: false,
           } as UpdateLog),
         })
+        return false
       }
     } catch (error) {
       this.logger.sendToChannel({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,7 +3148,7 @@
   "resolved" "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
   "version" "1.1.1"
 
-"accepts@~1.3.4", "accepts@~1.3.5", "accepts@~1.3.8":
+"accepts@~1.3.4", "accepts@~1.3.5", "accepts@~1.3.7", "accepts@~1.3.8":
   "integrity" "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="
   "resolved" "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
   "version" "1.3.8"
@@ -3983,21 +3983,39 @@
   "resolved" "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
   "version" "4.12.0"
 
-"body-parser@1.19.1", "body-parser@1.19.2":
-  "integrity" "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw=="
-  "resolved" "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz"
-  "version" "1.19.2"
+"body-parser@1.19.1":
+  "integrity" "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA=="
+  "resolved" "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz"
+  "version" "1.19.1"
   dependencies:
-    "bytes" "3.1.2"
+    "bytes" "3.1.1"
     "content-type" "~1.0.4"
     "debug" "2.6.9"
     "depd" "~1.1.2"
     "http-errors" "1.8.1"
     "iconv-lite" "0.4.24"
     "on-finished" "~2.3.0"
-    "qs" "6.9.7"
-    "raw-body" "2.4.3"
+    "qs" "6.9.6"
+    "raw-body" "2.4.2"
     "type-is" "~1.6.18"
+
+"body-parser@1.20.0":
+  "integrity" "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg=="
+  "resolved" "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz"
+  "version" "1.20.0"
+  dependencies:
+    "bytes" "3.1.2"
+    "content-type" "~1.0.4"
+    "debug" "2.6.9"
+    "depd" "2.0.0"
+    "destroy" "1.2.0"
+    "http-errors" "2.0.0"
+    "iconv-lite" "0.4.24"
+    "on-finished" "2.4.1"
+    "qs" "6.10.3"
+    "raw-body" "2.5.1"
+    "type-is" "~1.6.18"
+    "unpipe" "1.0.0"
 
 "bonjour-service@^1.0.11":
   "integrity" "sha512-pMmguXYCu63Ug37DluMKEHdxc+aaIf/ay4YbF8Gxtba+9d3u+rmEWy61VK3Z3hp8Rskok3BunHYnG0dUHAsblw=="
@@ -4169,6 +4187,11 @@
   "integrity" "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
   "resolved" "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
   "version" "3.0.0"
+
+"bytes@3.1.1":
+  "integrity" "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+  "resolved" "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz"
+  "version" "3.1.1"
 
 "bytes@3.1.2":
   "integrity" "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
@@ -4791,10 +4814,15 @@
   "resolved" "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   "version" "1.0.6"
 
-"cookie@0.4.2":
-  "integrity" "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-  "resolved" "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz"
-  "version" "0.4.2"
+"cookie@0.4.1":
+  "integrity" "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+  "resolved" "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz"
+  "version" "0.4.1"
+
+"cookie@0.5.0":
+  "integrity" "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+  "resolved" "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
+  "version" "0.5.0"
 
 "core-js-compat@^3.14.0", "core-js-compat@^3.16.2", "core-js-compat@^3.20.2", "core-js-compat@^3.21.0":
   "integrity" "sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g=="
@@ -5334,10 +5362,20 @@
   "resolved" "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   "version" "1.1.2"
 
+"depd@2.0.0":
+  "integrity" "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+  "resolved" "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
+  "version" "2.0.0"
+
 "destroy@~1.0.4":
   "integrity" "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
   "resolved" "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
   "version" "1.0.4"
+
+"destroy@1.2.0":
+  "integrity" "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+  "resolved" "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
+  "version" "1.2.0"
 
 "detect-libc@^1.0.3":
   "integrity" "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
@@ -6306,17 +6344,17 @@
   dependencies:
     "ws" "^7.4.6"
 
-"express@^4.0.0 || ^5.0.0-alpha.1", "express@^4.17.1", "express@^4.17.3", "express@4.17.2":
-  "integrity" "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg=="
-  "resolved" "https://registry.npmjs.org/express/-/express-4.17.3.tgz"
-  "version" "4.17.3"
+"express@^4.0.0 || ^5.0.0-alpha.1", "express@^4.17.1", "express@4.17.2":
+  "integrity" "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg=="
+  "resolved" "https://registry.npmjs.org/express/-/express-4.17.2.tgz"
+  "version" "4.17.2"
   dependencies:
-    "accepts" "~1.3.8"
+    "accepts" "~1.3.7"
     "array-flatten" "1.1.1"
-    "body-parser" "1.19.2"
+    "body-parser" "1.19.1"
     "content-disposition" "0.5.4"
     "content-type" "~1.0.4"
-    "cookie" "0.4.2"
+    "cookie" "0.4.1"
     "cookie-signature" "1.0.6"
     "debug" "2.6.9"
     "depd" "~1.1.2"
@@ -6331,13 +6369,50 @@
     "parseurl" "~1.3.3"
     "path-to-regexp" "0.1.7"
     "proxy-addr" "~2.0.7"
-    "qs" "6.9.7"
+    "qs" "6.9.6"
     "range-parser" "~1.2.1"
     "safe-buffer" "5.2.1"
     "send" "0.17.2"
     "serve-static" "1.14.2"
     "setprototypeof" "1.2.0"
     "statuses" "~1.5.0"
+    "type-is" "~1.6.18"
+    "utils-merge" "1.0.1"
+    "vary" "~1.1.2"
+
+"express@^4.17.3":
+  "integrity" "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q=="
+  "resolved" "https://registry.npmjs.org/express/-/express-4.18.1.tgz"
+  "version" "4.18.1"
+  dependencies:
+    "accepts" "~1.3.8"
+    "array-flatten" "1.1.1"
+    "body-parser" "1.20.0"
+    "content-disposition" "0.5.4"
+    "content-type" "~1.0.4"
+    "cookie" "0.5.0"
+    "cookie-signature" "1.0.6"
+    "debug" "2.6.9"
+    "depd" "2.0.0"
+    "encodeurl" "~1.0.2"
+    "escape-html" "~1.0.3"
+    "etag" "~1.8.1"
+    "finalhandler" "1.2.0"
+    "fresh" "0.5.2"
+    "http-errors" "2.0.0"
+    "merge-descriptors" "1.0.1"
+    "methods" "~1.1.2"
+    "on-finished" "2.4.1"
+    "parseurl" "~1.3.3"
+    "path-to-regexp" "0.1.7"
+    "proxy-addr" "~2.0.7"
+    "qs" "6.10.3"
+    "range-parser" "~1.2.1"
+    "safe-buffer" "5.2.1"
+    "send" "0.18.0"
+    "serve-static" "1.15.0"
+    "setprototypeof" "1.2.0"
+    "statuses" "2.0.1"
     "type-is" "~1.6.18"
     "utils-merge" "1.0.1"
     "vary" "~1.1.2"
@@ -6571,6 +6646,19 @@
     "on-finished" "~2.3.0"
     "parseurl" "~1.3.3"
     "statuses" "~1.5.0"
+    "unpipe" "~1.0.0"
+
+"finalhandler@1.2.0":
+  "integrity" "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg=="
+  "resolved" "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz"
+  "version" "1.2.0"
+  dependencies:
+    "debug" "2.6.9"
+    "encodeurl" "~1.0.2"
+    "escape-html" "~1.0.3"
+    "on-finished" "2.4.1"
+    "parseurl" "~1.3.3"
+    "statuses" "2.0.1"
     "unpipe" "~1.0.0"
 
 "find-cache-dir@^3.3.1":
@@ -7458,6 +7546,17 @@
     "inherits" "2.0.4"
     "setprototypeof" "1.2.0"
     "statuses" ">= 1.5.0 < 2"
+    "toidentifier" "1.0.1"
+
+"http-errors@2.0.0":
+  "integrity" "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="
+  "resolved" "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "depd" "2.0.0"
+    "inherits" "2.0.4"
+    "setprototypeof" "1.2.0"
+    "statuses" "2.0.1"
     "toidentifier" "1.0.1"
 
 "http-parser-js@>=0.5.1":
@@ -10317,6 +10416,13 @@
   dependencies:
     "ee-first" "1.1.1"
 
+"on-finished@2.4.1":
+  "integrity" "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="
+  "resolved" "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
+  "version" "2.4.1"
+  dependencies:
+    "ee-first" "1.1.1"
+
 "on-headers@~1.0.2":
   "integrity" "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
   "resolved" "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz"
@@ -11155,10 +11261,17 @@
   "resolved" "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz"
   "version" "6.5.3"
 
-"qs@6.9.7":
-  "integrity" "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
-  "resolved" "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz"
-  "version" "6.9.7"
+"qs@6.10.3":
+  "integrity" "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ=="
+  "resolved" "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz"
+  "version" "6.10.3"
+  dependencies:
+    "side-channel" "^1.0.4"
+
+"qs@6.9.6":
+  "integrity" "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+  "resolved" "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz"
+  "version" "6.9.6"
 
 "query-string@^5.0.1":
   "integrity" "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw=="
@@ -11203,13 +11316,23 @@
   "resolved" "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
   "version" "1.2.1"
 
-"raw-body@2.4.3":
-  "integrity" "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g=="
-  "resolved" "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz"
-  "version" "2.4.3"
+"raw-body@2.4.2":
+  "integrity" "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ=="
+  "resolved" "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz"
+  "version" "2.4.2"
+  dependencies:
+    "bytes" "3.1.1"
+    "http-errors" "1.8.1"
+    "iconv-lite" "0.4.24"
+    "unpipe" "1.0.0"
+
+"raw-body@2.5.1":
+  "integrity" "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig=="
+  "resolved" "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz"
+  "version" "2.5.1"
   dependencies:
     "bytes" "3.1.2"
-    "http-errors" "1.8.1"
+    "http-errors" "2.0.0"
     "iconv-lite" "0.4.24"
     "unpipe" "1.0.0"
 
@@ -12063,6 +12186,25 @@
     "range-parser" "~1.2.1"
     "statuses" "~1.5.0"
 
+"send@0.18.0":
+  "integrity" "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg=="
+  "resolved" "https://registry.npmjs.org/send/-/send-0.18.0.tgz"
+  "version" "0.18.0"
+  dependencies:
+    "debug" "2.6.9"
+    "depd" "2.0.0"
+    "destroy" "1.2.0"
+    "encodeurl" "~1.0.2"
+    "escape-html" "~1.0.3"
+    "etag" "~1.8.1"
+    "fresh" "0.5.2"
+    "http-errors" "2.0.0"
+    "mime" "1.6.0"
+    "ms" "2.1.3"
+    "on-finished" "2.4.1"
+    "range-parser" "~1.2.1"
+    "statuses" "2.0.1"
+
 "serialize-error@^7.0.1":
   "integrity" "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="
   "resolved" "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz"
@@ -12099,6 +12241,16 @@
     "escape-html" "~1.0.3"
     "parseurl" "~1.3.3"
     "send" "0.17.2"
+
+"serve-static@1.15.0":
+  "integrity" "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g=="
+  "resolved" "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz"
+  "version" "1.15.0"
+  dependencies:
+    "encodeurl" "~1.0.2"
+    "escape-html" "~1.0.3"
+    "parseurl" "~1.3.3"
+    "send" "0.18.0"
 
 "set-blocking@^2.0.0":
   "integrity" "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
@@ -12517,6 +12669,11 @@
   "integrity" "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
   "resolved" "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   "version" "1.5.0"
+
+"statuses@2.0.1":
+  "integrity" "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+  "resolved" "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
+  "version" "2.0.1"
 
 "stream-shift@^1.0.0":
   "integrity" "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="


### PR DESCRIPTION
Organized point node update and launch process:
- Made logic in `checkForUpdates` function more straightforward
- Moved all the dashboard logic to contexts
- Promisified some IPC messaging channels
- As a result, now we have much more straightforward logic of checking, updating and launching node, firefox and SDK. We got rid of all timeouts, instead one, and cross-calling functions from each other. Also, we are now sure that we first download and install updates (if needed), and only then run node/firefox. Previously we had to stop it if updates were found.

Bugfixes:
- Fixed updating modal, it was not showing competely, bc listeners were initialized inside `ResourceUpdateCard` components, which were not mounted at that moment
- Small fix: moved `window.loadURL` after creating `node`, `firefox`, `pointSDK` and `uninstaller` classes - now we can be sure they exist when we call their methods
