### PR TITLE
Catch critical errors from Point Engine

### DIFF
--- a/src/@types/context.d.ts
+++ b/src/@types/context.d.ts
@@ -1,8 +1,4 @@
-import {
-  GenericProgressLog,
-  IsUpdatingState,
-  UpdateLog,
-} from './generic'
+import { GenericProgressLog, IsUpdatingState, UpdateLog } from './generic'
 
 export type MainStatus = {
   isBrowserRunning: boolean
@@ -20,6 +16,7 @@ export type MainStatus = {
     address: string
   }
   balance: string | number
+  engineErrorCode: number
 }
 
 export type UpdateStatus = {

--- a/src/@types/ipc_channels.ts
+++ b/src/@types/ipc_channels.ts
@@ -58,6 +58,7 @@ export enum NodeChannelsEnum {
   running_status = 'node:running_status',
   stop = 'node:stop',
   unpack = 'node:unpack',
+  error = 'node:error',
 }
 
 export enum UninstallerChannelsEnum {

--- a/src/dashboard/context/MainStatusContext.ts
+++ b/src/dashboard/context/MainStatusContext.ts
@@ -20,6 +20,7 @@ export const useMainStatus = () => {
   // Node
   const [nodeVersion, setNodeVersion] = useState<string>('')
   const [isNodeRunning, setIsNodeRunning] = useState<boolean>(false)
+  const [engineErrorCode, setEngineErrorCode] = useState<number>(0)
   // Browser
   const [browserVersion, setBrowserVersion] = useState<string>('')
   const [isBrowserRunning, setIsBrowserRunning] = useState<boolean>(false)
@@ -35,6 +36,13 @@ export const useMainStatus = () => {
 
   // Register these events once to prevent leaks
   const setListeners = () => {
+    window.Dashboard.on(NodeChannelsEnum.error, (log: string) => {
+      const parsed: LaunchProcessLog = JSON.parse(log)
+      setIsNodeRunning(parsed.isRunning)
+      setEngineErrorCode(+parsed.log)
+      setIsLaunching({ isLoading: false, message: '' })
+    })
+
     window.Dashboard.on(NodeChannelsEnum.running_status, (_: string) => {
       const parsed: LaunchProcessLog = JSON.parse(_)
       setIsNodeRunning(parsed.isRunning)
@@ -70,10 +78,10 @@ export const useMainStatus = () => {
       if (parsed.success) {
         setIsLaunching({
           isLoading: true,
-          message: 'Starting Point Network'
+          message: 'Starting Point Network',
         })
       } else {
-        setIsLaunching({isLoading: false, message: ''})
+        setIsLaunching({ isLoading: false, message: '' })
       }
     })
 
@@ -144,6 +152,7 @@ export const useMainStatus = () => {
     loader,
     identityInfo,
     balance,
+    engineErrorCode,
   }
 }
 

--- a/src/dashboard/ui/App.tsx
+++ b/src/dashboard/ui/App.tsx
@@ -29,7 +29,7 @@ const App = () => {
       <DashboardUpdateAlert />
       <TimeoutAlert identifier={identifier} launchAttempts={launchAttempts} />
       <CheckForUpdatesDialog />
-      <ErrorDialog errCode={engineErrorCode} />
+      <ErrorDialog identifier={identifier} errCode={engineErrorCode} />
 
       <DefaultLoader
         isOpen={loader.isLoading && !updateDialogOpen}

--- a/src/dashboard/ui/App.tsx
+++ b/src/dashboard/ui/App.tsx
@@ -15,10 +15,12 @@ import DisplayIdentifier from '../../../shared/react-components/DisplayIdentifie
 import MainContent from './components/MainContent'
 import Sidebar from './components/Sidebar'
 import TimeoutAlert from './components/TimeoutAlert'
+import ErrorDialog from './components/ErrorDialog'
 import UIThemeProvider from '../../../shared/react-components/UIThemeProvider'
 
 const App = () => {
-  const { identifier, launchAttempts, loader } = useContext(MainStatusContext)
+  const { identifier, launchAttempts, loader, engineErrorCode } =
+    useContext(MainStatusContext)
   const { updateDialogOpen } = useContext(UpdateStatusContext)
 
   return (
@@ -26,8 +28,8 @@ const App = () => {
       <DisplayIdentifier identifier={identifier} />
       <DashboardUpdateAlert />
       <TimeoutAlert identifier={identifier} launchAttempts={launchAttempts} />
-
       <CheckForUpdatesDialog />
+      <ErrorDialog errCode={engineErrorCode} />
 
       <DefaultLoader
         isOpen={loader.isLoading && !updateDialogOpen}

--- a/src/dashboard/ui/components/ContactSupport.tsx
+++ b/src/dashboard/ui/components/ContactSupport.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react'
+import IconButton from '@mui/material/IconButton'
+import Chip from '@mui/material/Chip'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import CheckIcon from '@mui/icons-material/Check'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import { GenericChannelsEnum } from '../../../@types/ipc_channels'
+import ExternalLink from '../../../../shared/react-components/ExternalLink'
+
+type Props = { identifier: string }
+
+const ContactSupport = ({ identifier }: Props) => {
+  const [copied, setCopied] = useState<boolean>(false)
+
+  useEffect(() => {
+    window.Dashboard.on(GenericChannelsEnum.copy_to_clipboard, () => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 3000)
+    })
+  }, [])
+
+  return (
+    <Box py={3}>
+      <Typography>
+        If the problem persists, please try to uninstall and reinstall the
+        Dashboard or contact the support team{' '}
+        <ExternalLink
+          onClick={() =>
+            window.Dashboard.openExternalLink('https://pointnetwork.io/support')
+          }
+        >
+          here
+        </ExternalLink>{' '}
+        with your support ID -{' '}
+      </Typography>
+      <Box display="flex" alignItems="center" mt={1}>
+        <Chip label={identifier} sx={{ mr: 0.5 }} />
+        {copied ? (
+          <Box display="flex" alignItems="center">
+            <IconButton>
+              <CheckIcon fontSize="small" />
+            </IconButton>
+            <Typography variant="body2">Copied!</Typography>
+          </Box>
+        ) : (
+          <Box display="flex" alignItems="center">
+            <IconButton
+              onClick={() => window.Dashboard.copyToClipboard(identifier)}
+            >
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+            <Typography variant="body2">Click to Copy</Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default ContactSupport

--- a/src/dashboard/ui/components/ErrorDialog.tsx
+++ b/src/dashboard/ui/components/ErrorDialog.tsx
@@ -22,6 +22,11 @@ const PointErrorCodes: Record<number, PointErr> = {
     name: 'DDBB_FAILED_MIGRATION',
     text: 'Failed to run database migrations.',
   },
+  14: {
+    code: 14,
+    name: 'INVALID_CHECKSUM',
+    text: 'Checksum for downloaded file does not match the expected one.',
+  },
 }
 
 function getButtonByError(code: number) {
@@ -38,7 +43,7 @@ function getButtonByError(code: number) {
     )
   }
 
-  if (code === 12 || code === 13) {
+  if (code === 12 || code === 13 || code === 14) {
     return (
       <Button
         color="error"
@@ -61,6 +66,15 @@ function getInstructionsByError(code: number) {
         If you have manually edited `key.json`, you may fix it and restart the
         Point Dashboard. Otherwise, click on the button below to log out and
         create a new account or import an existing one.
+      </Typography>
+    )
+  }
+
+  if (code === 14) {
+    return (
+      <Typography>
+        Please make sure your network is working correctly. Close the Dashboard
+        and restart it to trigger a new download.
       </Typography>
     )
   }

--- a/src/dashboard/ui/components/ErrorDialog.tsx
+++ b/src/dashboard/ui/components/ErrorDialog.tsx
@@ -2,25 +2,30 @@ import Dialog from '@mui/material/Dialog'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
+import ContactSupport from './ContactSupport'
 
-// TODO: this will come from a shared repo of `point-error-codes`
+// TODO: this will come from a shared repo of `point-error-codes`.
 type PointErr = { code: number; name: string; text: string }
 const PointErrorCodes: Record<number, PointErr> = {
-  7: {
-    code: 7,
+  11: {
+    code: 11,
     name: 'INVALID_KEYFILE',
-    text: 'Keyfile does not contain the expect format/data',
+    text: 'Keyfile has missing or invalid data.',
+  },
+  12: {
+    code: 12,
+    name: 'LOCKFILE_PRESENT',
+    text: 'Unable to create lockfile, process must be already running.',
+  },
+  13: {
+    code: 13,
+    name: 'DDBB_FAILED_MIGRATION',
+    text: 'Failed to run database migrations.',
   },
 }
 
-const genericError = {
-  code: NaN,
-  name: 'POINT_ENGINE_ERROR',
-  text: 'Unable to launch Point Engine',
-}
-
 function getButtonByError(code: number) {
-  if (code === 7) {
+  if (code === 11) {
     return (
       <Button
         color="primary"
@@ -33,11 +38,24 @@ function getButtonByError(code: number) {
     )
   }
 
+  if (code === 12 || code === 13) {
+    return (
+      <Button
+        color="error"
+        variant="contained"
+        size="small"
+        onClick={window.Dashboard.closeWindow}
+      >
+        Close
+      </Button>
+    )
+  }
+
   return null
 }
 
 function getInstructionsByError(code: number) {
-  if (code === 7) {
+  if (code === 11) {
     return (
       <Typography>
         If you have manually edited `key.json`, you may fix it and restart the
@@ -52,10 +70,13 @@ function getInstructionsByError(code: number) {
 
 type Props = {
   errCode: number
+  identifier: string
 }
 
-const ErrorDialog = ({ errCode }: Props) => {
-  const error = PointErrorCodes[errCode] || genericError
+const ErrorDialog = ({ errCode, identifier }: Props) => {
+  const pointErr = PointErrorCodes[errCode]
+
+  if (!pointErr) return null
 
   return (
     <Dialog open={errCode > 0}>
@@ -70,11 +91,13 @@ const ErrorDialog = ({ errCode }: Props) => {
           p={2}
         >
           <Typography>
-            {error.name}: {error.text}
+            {pointErr.name}: {pointErr.text}
           </Typography>
         </Box>
 
         {getInstructionsByError(errCode)}
+
+        <ContactSupport identifier={identifier} />
 
         <Box display="flex" justifyContent="flex-end" mt={2}>
           {getButtonByError(errCode)}

--- a/src/dashboard/ui/components/ErrorDialog.tsx
+++ b/src/dashboard/ui/components/ErrorDialog.tsx
@@ -1,0 +1,87 @@
+import Dialog from '@mui/material/Dialog'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+
+// TODO: this will come from a shared repo of `point-error-codes`
+type PointErr = { code: number; name: string; text: string }
+const PointErrorCodes: Record<number, PointErr> = {
+  7: {
+    code: 7,
+    name: 'INVALID_KEYFILE',
+    text: 'Keyfile does not contain the expect format/data',
+  },
+}
+
+const genericError = {
+  code: NaN,
+  name: 'POINT_ENGINE_ERROR',
+  text: 'Unable to launch Point Engine',
+}
+
+function getButtonByError(code: number) {
+  if (code === 7) {
+    return (
+      <Button
+        color="primary"
+        variant="contained"
+        size="small"
+        onClick={window.Dashboard.logOut}
+      >
+        Log Out
+      </Button>
+    )
+  }
+
+  return null
+}
+
+function getInstructionsByError(code: number) {
+  if (code === 7) {
+    return (
+      <Typography>
+        If you have manually edited `key.json`, you may fix it and restart the
+        Point Dashboard. Otherwise, click on the button below to log out and
+        create a new account or import an existing one.
+      </Typography>
+    )
+  }
+
+  return null
+}
+
+type Props = {
+  errCode: number
+}
+
+const ErrorDialog = ({ errCode }: Props) => {
+  const error = PointErrorCodes[errCode] || genericError
+
+  return (
+    <Dialog open={errCode > 0}>
+      <Box p={3}>
+        <Typography variant="h5" gutterBottom>
+          Sorry, we have run into an error.
+        </Typography>
+
+        <Box
+          sx={{ backgroundColor: '#eee', border: '1px solid #ddd' }}
+          my={2}
+          p={2}
+        >
+          <Typography>
+            {error.name}: {error.text}
+          </Typography>
+        </Box>
+
+        {getInstructionsByError(errCode)}
+
+        <Box display="flex" justifyContent="flex-end" mt={2}>
+          {getButtonByError(errCode)}
+        </Box>
+      </Box>
+    </Dialog>
+  )
+}
+
+export default ErrorDialog

--- a/src/dashboard/ui/components/TimeoutAlert.tsx
+++ b/src/dashboard/ui/components/TimeoutAlert.tsx
@@ -1,18 +1,10 @@
-import { useEffect, useState } from 'react'
 // MUI
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Chip from '@mui/material/Chip'
 import Dialog from '@mui/material/Dialog'
-import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 // Components
-import ExternalLink from '../../../../shared/react-components/ExternalLink'
-// Icons
-import CheckIcon from '@mui/icons-material/Check'
-import ContentCopyIcon from '@mui/icons-material/ContentCopy'
-// Types
-import { GenericChannelsEnum } from '../../../@types/ipc_channels'
+import ContactSupport from './ContactSupport'
 
 const TimeoutAlert = ({
   identifier,
@@ -21,54 +13,14 @@ const TimeoutAlert = ({
   identifier: string
   launchAttempts: number
 }) => {
-  const [copied, setCopied] = useState<boolean>(false)
-
-  useEffect(() => {
-    window.Dashboard.on(GenericChannelsEnum.copy_to_clipboard, () => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 3000)
-    })
-  }, [])
-
   return (
     <Dialog open={launchAttempts >= 10}>
       <Box p={3}>
         <Typography>
           Failed to start Point Network. Please, close and reopen Point
-          Dashboard. If the problem persists, please try to uninstall and
-          reinstall the dashboard by clicking the "Uninstall" button or contact
-          the support team{' '}
-          <ExternalLink
-            onClick={() =>
-              window.Dashboard.openExternalLink(
-                'https://pointnetwork.io/support'
-              )
-            }
-          >
-            here
-          </ExternalLink>{' '}
-          with your support ID -{' '}
+          Dashboard.
         </Typography>
-        <Box display="flex" alignItems="center" mt={1}>
-          <Chip label={identifier} sx={{ mr: 0.5 }} />
-          {copied ? (
-            <Box display="flex" alignItems="center">
-              <IconButton>
-                <CheckIcon fontSize="small" />
-              </IconButton>
-              <Typography variant="body2">Copied!</Typography>
-            </Box>
-          ) : (
-            <Box display="flex" alignItems="center">
-              <IconButton
-                onClick={() => window.Dashboard.copyToClipboard(identifier)}
-              >
-                <ContentCopyIcon fontSize="small" />
-              </IconButton>
-              <Typography variant="body2">Click to Copy</Typography>
-            </Box>
-          )}
-        </Box>
+        <ContactSupport identifier={identifier} />
         <Box display="flex" justifyContent="flex-end" mt={2}>
           <Button
             color="error"

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow } from 'electron'
 import axios from 'axios'
-import fs  from 'fs-extra'
+import fs from 'fs-extra'
 import path from 'node:path'
 import find from 'find-process'
 import { spawn } from 'node:child_process'
@@ -92,14 +92,14 @@ class Node {
         if (global.platform.darwin)
           fileName = `point-macos-${latestVersion}.tar.gz`
 
-        const platform = fileName.split('-')[1];
-        const downloadUrl = this.getDownloadURL(fileName, latestVersion);
-        const downloadDest = path.join(this.pointDir, fileName);
-        const sha256FileName = `sha256-${latestVersion}.txt`;
-        const sumFileDest = path.join(this.pointDir, sha256FileName);
-        const sumFileUrl = this.getDownloadURL(sha256FileName, latestVersion);
+        const platform = fileName.split('-')[1]
+        const downloadUrl = this.getDownloadURL(fileName, latestVersion)
+        const downloadDest = path.join(this.pointDir, fileName)
+        const sha256FileName = `sha256-${latestVersion}.txt`
+        const sumFileDest = path.join(this.pointDir, sha256FileName)
+        const sumFileUrl = this.getDownloadURL(sha256FileName, latestVersion)
 
-        this.logger.info('Downloading from', downloadUrl);
+        this.logger.info('Downloading from', downloadUrl)
 
         try {
           await downloadAndVerifyFileIntegrity({
@@ -109,14 +109,14 @@ class Node {
             sumFileUrl,
             sumFileDest,
             logger: this.logger,
-            channel: NodeChannelsEnum.download
-          });
-
+            channel: NodeChannelsEnum.download,
+          })
         } catch (e) {
-          this.logger.error(`Could not download pointnode after many retries due to error: ${e}`)
+          this.logger.error(
+            `Could not download pointnode after many retries due to error: ${e}`
+          )
           throw e
         }
-
 
         this.logger.info('Unpacking')
         // 3. Unpack the downloaded file and send logs to window
@@ -190,7 +190,9 @@ class Node {
     try {
       this.logger.info('Launching point node')
       if (!fs.existsSync(await this._getBinFile())) {
-        this.logger.error('Trying to launch point node, but bin file does not exist')
+        this.logger.error(
+          'Trying to launch point node, but bin file does not exist'
+        )
         return
       }
       if ((await this._getRunningProcess()).length) {
@@ -203,9 +205,9 @@ class Node {
       const proc = spawn(file, {
         env: {
           ...process.env,
-          NODE_ENV: 'production'
+          NODE_ENV: 'production',
         },
-        stdio: ['ignore', 'ignore', 'pipe']
+        stdio: ['ignore', 'ignore', 'pipe'],
       })
 
       proc.stderr.on('data', data => {
@@ -223,7 +225,6 @@ class Node {
       if (!this.pingInterval) {
         this.pingInterval = setInterval(this.ping.bind(this), PING_INTERVAL)
       }
-
     } catch (error) {
       this.logger.error(ErrorsEnum.LAUNCH_ERROR, error)
       throw error


### PR DESCRIPTION
Please refer to [the ticket](https://point-labs.atlassian.net/browse/PD-254) for context.

[This video](https://drive.google.com/file/d/1ULmd1L-EqmPPVbmqVminiBjdwcRHf6Hw/view?usp=sharing) explains the flow and shows a few examples of Engine and Dashboard working with the same error codes.

[This other ticket](https://point-labs.atlassian.net/browse/PN-182) offers further details on the shared error codes that will be created next. Once done, some changes will be required in Dashboard to make use of such shared errors.