### PR TITLE
PD-291 Delay requests to faucet when an error is returned

### DIFF
--- a/src/@types/results.ts
+++ b/src/@types/results.ts
@@ -1,0 +1,3 @@
+export type Result<E, V> = {success: false; error: E} | {success: true; value: V};
+
+export type BalanceCheckResult = Result<Error, number>;


### PR DESCRIPTION
The main goal of this PR is to stop using a `setInterval` to query the balance of the user, and instead recursively call the `getBalance` function, with a setTimeout, after a response for the previous request has been received.

This serves two main purposes:

1. Don't make a new request if the previous one is still in progress.
2. Increase the timeout for the next request if the previous response was an error, so that we don't overwhelm the faucet service if it is already struggling to keep up with requests.

I have also made a change so that if there's an error received from the faucet, instead of setting the balance to zero, we leave it as is, it will be updated on the next successful balance check. This means we could sometimes show an outdated balance for a longer time, but that's probably a better UX than setting the balance to zero, as it may scare users.

---

As a side effect, I changed the response format of the  `DashboardChannelsEnum.check_balance_and_airdrop` message. I created a generic `Result` type that we could use for all IPC messages.

Since communication is done by sending messages through channels, I don't think throwing errors is an option. And having error channels could be harder to manage, as we would completely separate values from errors.

`Result` can either have a value or an error (much like Rust's `Result`). I think this provides a nice API because on the receiving side, one just needs to check the `success` field of the `Result` and typescript will know if it has a `value` or an `error` inside the conditional, it will know exactly the type of the value. To illustrate:

```typescript
function someFunc(): Result<Error, number> { ... }

const result = someFunc()
if (result.success) {
    // TS correctly infers that result here is:
    //     `{success: true, value: number}`
} else {
    // TS correctly infers that result here is:
    //    `{success: false, error: Error}`
}
```

But if you find this too strange or not convenient, please let me know and we'll look for a different approach.

An alternative idea is to use a Result like:
```typescript
type Result<E, V> = {
  error?: E
  value: V
}
```

But the downside is that we either have to make `value` optional (`value?: V`) and check it before using it, or include it in error messages too, with a "zero value" for the corresponding type (`""`, `0`, `false`, etc).